### PR TITLE
Add max-memory option to IPFS.  Remove 1G default from signal.  Move …

### DIFF
--- a/packages/cli-core/src/runnable.js
+++ b/packages/cli-core/src/runnable.js
@@ -13,7 +13,7 @@ import pify from 'pify';
 const PROCESS_PREFIX = 'dxos.';
 const STATUS_RUNNING = 'online';
 
-const MAX_MEMORY = '200M';
+const MAX_MEMORY = '500M';
 
 const pm = {
   connect: pify(pm2.connect.bind(pm2)),

--- a/packages/cli-ipfs/src/modules/ipfs.js
+++ b/packages/cli-ipfs/src/modules/ipfs.js
@@ -50,10 +50,11 @@ export const IPFSModule = ({ config }) => ({
           default: true
         })
         .option('connect-interval', { type: 'number', default: 300 })
-        .option('connect-ipv6', { type: 'boolean', default: false }),
+        .option('connect-ipv6', { type: 'boolean', default: false })
+        .option('max-memory', { type: 'string' }),
 
       handler: asyncHandler(async argv => {
-        const { logFile, daemon, procName, forward, connectInterval, connectIpv6, wnsBootstrap } = argv;
+        const { logFile, daemon, procName, forward, connectInterval, connectIpv6, wnsBootstrap, maxMemory } = argv;
         const forwardArgs = forward ? JSON.parse(forward).args : [];
 
         if (wnsBootstrap && connectInterval >= 0) {
@@ -75,7 +76,8 @@ export const IPFSModule = ({ config }) => ({
           name: procName,
           detached: daemon,
           singleInstance: true,
-          logFile
+          logFile,
+          maxMemory
         };
         await ipfsRunnable.run(['daemon', '--writable', ...forwardArgs], ipfsOptions);
       })

--- a/packages/cli-signal/src/modules/signal.js
+++ b/packages/cli-signal/src/modules/signal.js
@@ -14,8 +14,6 @@ import { log } from '@dxos/debug';
 const SIGNAL_PROCESS_NAME = 'signal';
 const DEFAULT_LOG_FILE = '/var/log/signal.log';
 
-const DEFAULT_MAX_MEMORY = '1G';
-
 const WRN_TYPE = 'wrn:service';
 const SERVICE_TYPE = 'signal';
 
@@ -73,7 +71,7 @@ export const SignalModule = ({ config }) => {
           .option('log-file', { type: 'string' })
           .option('proc-name', { type: 'string', default: SIGNAL_PROCESS_NAME })
           .option('daemon')
-          .option('max-memory', { type: 'string', default: DEFAULT_MAX_MEMORY }),
+          .option('max-memory', { type: 'string' }),
 
         handler: asyncHandler(async ({
           daemon,


### PR DESCRIPTION
…everything to 500M default.

We are not targeting the 512MB platforms anymore, and we really don't want to use this feature to control memory usage, but only to deal with run-away conditions.

At 200MB, we occasionally see IPFS get killed and restarted when it was otherwise working properly.