### PR TITLE
Key generation doesn't need active profile.

### DIFF
--- a/packages/cli-core/src/cli-factory.js
+++ b/packages/cli-core/src/cli-factory.js
@@ -19,6 +19,7 @@ export const EXTENSION_CONFIG_FILENAME = 'extension.yml';
 const COMMANDS_PERMIT_NO_PROFILE = [
   'help',
   'version',
+  'keys',
   'profile',
   'services'
 ];


### PR DESCRIPTION
```
~/projects/dxos/cli ashwinp-keys-generate ❯ yarn wire keys generate                                                                                                                                                                                                        6s
yarn run v1.22.4
$ /Users/ashwinp/projects/dxos/cli/node_modules/.bin/wire keys generate
key         value
----------  -------------------------------------------------------------------
mnemonic    dance diet idle call supply senior vapor load dash box prosper good
privateKey  b77ea342ba215187c5fd636886d4f979f5dd6b0b75f7358ab487f9dd865753d4
publicKey   038385014e7ccce5dc0de1cfdf1b6d7ac9db480f4441738879943a57ff5af2d8b8
address     cosmos1lj92aenqum4se7mzn8susk9mg2ufqz5t2mk2cs

✨  Done in 1.14s.
~/projects/dxos/cli ashwinp-keys-generate ❯ ls ~/.wire/profile
~/projects/dxos/cli ashwinp-keys-generate ❯
```