### PR TITLE
chore: Upgrade DXOS dependencies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
     specifiers:
       '@dxos/cli-core': workspace:*
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/random-access-multi-storage': ~2.23.0
       '@types/jest': ~27.0.3
       '@types/js-yaml': ^3.12.5
@@ -70,7 +70,7 @@ importers:
       url-join: 4.0.1
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/js-yaml': 3.12.7
       '@types/node': 16.11.14
@@ -87,9 +87,9 @@ importers:
       '@dxos/cli-core': workspace:*
       '@dxos/cli-dxns': workspace:*
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/registry-client': ~2.23.0
-      '@dxos/util': ^2.15.6
+      '@dxos/util': ^2.23.0
       '@otplib/plugin-thirty-two': ^12.0.1
       '@polkadot/api': 4.17.1
       '@types/body-parser': ^1.19.1
@@ -153,7 +153,7 @@ importers:
       '@dxos/cli-core': link:../cli-core
       '@dxos/debug': 2.23.0
       '@dxos/registry-client': 2.23.0
-      '@dxos/util': 2.22.0
+      '@dxos/util': 2.23.0
       '@otplib/plugin-thirty-two': 12.0.1
       '@polkadot/api': 4.17.1
       abort-controller: 3.0.0
@@ -189,7 +189,7 @@ importers:
       yargs: 16.2.0
     devDependencies:
       '@dxos/cli-dxns': link:../cli-dxns
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/body-parser': 1.19.2
       '@types/cli-progress': 3.9.2
       '@types/cookie-parser': 1.4.2
@@ -227,9 +227,9 @@ importers:
       '@dxos/config': ~2.23.0
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/registry-client': ~2.23.0
-      '@dxos/util': ^2.15.6
+      '@dxos/util': ^2.23.0
       '@types/cli-progress': ^3.9.2
       '@types/fs-extra': ^9.0.13
       '@types/jest': ~27.0.3
@@ -267,7 +267,7 @@ importers:
       '@dxos/crypto': 2.23.0
       '@dxos/debug': 2.23.0
       '@dxos/registry-client': 2.23.0
-      '@dxos/util': 2.22.0
+      '@dxos/util': 2.23.0
       abort-controller: 3.0.0
       assert: 2.0.0
       chance: 1.1.8
@@ -286,7 +286,7 @@ importers:
     devDependencies:
       '@dxos/cli-data': link:../cli-data
       '@dxos/cli-dxns': link:../cli-dxns
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/cli-progress': 3.9.2
       '@types/fs-extra': 9.0.13
       '@types/jest': 27.0.3
@@ -307,7 +307,7 @@ importers:
       '@dxos/cli-core': workspace:*
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/network-manager': ~2.23.0
       '@dxos/protocol-plugin-messenger': ~2.23.0
       '@dxos/protocol-plugin-presence': ~2.23.0
@@ -333,7 +333,7 @@ importers:
       hypercore-crypto: 1.0.0
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -347,7 +347,7 @@ importers:
     specifiers:
       '@dxos/cli-core': workspace:*
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@types/jest': ~27.0.3
       '@types/node': ~16.11.12
       '@types/yargs': ^16.0.1
@@ -390,7 +390,7 @@ importers:
       tar: 6.1.11
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -406,7 +406,7 @@ importers:
       '@dxos/config': ~2.23.0
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@otplib/plugin-thirty-two': ^12.0.1
       '@types/dockerode': ^3.2.3
       '@types/download': ^6.2.4
@@ -496,7 +496,7 @@ importers:
       yargs-parser: 19.0.4
       yargs-unparser: 1.6.4
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/dockerode': 3.3.0
       '@types/download': 6.2.4
       '@types/fs-extra': 9.0.13
@@ -525,7 +525,7 @@ importers:
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
       '@dxos/echo-db': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/random-access-multi-storage': ~2.23.0
       '@dxos/signal': ~2.23.0
       '@types/fs-extra': ^9.0.13
@@ -569,7 +569,7 @@ importers:
       yargs: 16.2.0
     devDependencies:
       '@dxos/async': 2.23.0
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@dxos/signal': 2.23.0
       '@types/fs-extra': 9.0.13
       '@types/jest': 27.0.3
@@ -591,7 +591,7 @@ importers:
       '@dxos/config': ~2.23.0
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/registry-client': ~2.23.0
       '@polkadot/api': 4.17.1
       '@polkadot/keyring': 6.11.1
@@ -657,7 +657,7 @@ importers:
       protobufjs: 6.11.2
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/bn.js': 5.1.0
       '@types/cli-progress': 3.9.2
       '@types/get-folder-size': 3.0.1
@@ -684,7 +684,7 @@ importers:
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
       '@dxos/echo-db': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/object-model': ~2.23.0
       '@types/jest': ~27.0.3
       '@types/node': ~16.11.12
@@ -706,7 +706,7 @@ importers:
     devDependencies:
       '@dxos/cli-data': link:../cli-data
       '@dxos/echo-db': 2.23.0
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -721,7 +721,7 @@ importers:
       '@dxos/cli-core': workspace:*
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/object-model': ~2.23.0
       '@types/jest': ~27.0.3
       '@types/node': ~16.11.12
@@ -741,7 +741,7 @@ importers:
       assert: 2.0.0
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -756,7 +756,7 @@ importers:
       '@dxos/async': ~2.23.0
       '@dxos/cli-core': workspace:*
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/registry-client': ~2.23.0
       '@polkadot/api': 4.17.1
       '@types/jest': ~27.0.3
@@ -804,7 +804,7 @@ importers:
       pify: 5.0.0
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -820,7 +820,7 @@ importers:
       '@dxos/cli-core': workspace:*
       '@dxos/crypto': ~2.23.0
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/object-model': ~2.23.0
       '@dxos/registry-client': ~2.23.0
       '@types/jest': ~27.0.3
@@ -853,7 +853,7 @@ importers:
       yamljs: 0.3.0
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/js-yaml': 3.12.7
       '@types/node': 16.11.14
@@ -869,7 +869,7 @@ importers:
     specifiers:
       '@dxos/cli-core': workspace:*
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@types/jest': ~27.0.3
       '@types/node': ~16.11.12
       '@types/yargs': ^16.0.1
@@ -884,7 +884,7 @@ importers:
       '@dxos/debug': 2.23.0
       assert: 2.0.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -898,7 +898,7 @@ importers:
     specifiers:
       '@dxos/async': ~2.23.0
       '@dxos/cli-core': workspace:*
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/network-manager': ~2.23.0
       '@types/jest': ~27.0.3
       '@types/node': ~16.11.12
@@ -923,7 +923,7 @@ importers:
       performance-now: 2.1.0
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -937,7 +937,7 @@ importers:
     specifiers:
       '@dxos/cli-core': workspace:*
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@types/jest': ~27.0.3
       '@types/node': ~16.11.12
       '@types/yargs': ^16.0.1
@@ -971,7 +971,7 @@ importers:
       semver: 7.3.5
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -984,7 +984,7 @@ importers:
     specifiers:
       '@dxos/cli-core': workspace:*
       '@dxos/debug': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@types/jest': ~27.0.3
       '@types/node': ~16.11.12
       '@types/yargs': ^16.0.1
@@ -1000,7 +1000,7 @@ importers:
       lodash-clean: 2.2.2
       yargs: 16.2.0
     devDependencies:
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
       '@types/yargs': 16.0.4
@@ -1015,9 +1015,9 @@ importers:
       '@dxos/botkit': ~2.23.0
       '@dxos/cli-core': workspace:*
       '@dxos/crypto': ~2.23.0
-      '@dxos/eslint-plugin': ~1.0.20
+      '@dxos/eslint-plugin': ~1.0.21
       '@dxos/signal': ~2.23.0
-      '@dxos/util': ^2.15.6
+      '@dxos/util': ^2.23.0
       '@types/expect': ^24.3.0
       '@types/express': ^4.17.13
       '@types/fs-extra': ^9.0.13
@@ -1041,9 +1041,9 @@ importers:
       '@dxos/botkit': 2.23.0
       '@dxos/cli-core': link:../cli-core
       '@dxos/crypto': 2.23.0
-      '@dxos/eslint-plugin': 1.0.20_eslint@7.32.0+typescript@4.5.4
+      '@dxos/eslint-plugin': 1.0.21_eslint@7.32.0+typescript@4.5.4
       '@dxos/signal': 2.23.0
-      '@dxos/util': 2.22.0
+      '@dxos/util': 2.23.0
       '@types/expect': 24.3.0
       '@types/express': 4.17.13
       '@types/fs-extra': 9.0.13
@@ -1570,27 +1570,12 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@dxos/crypto/2.22.0:
-    resolution: {integrity: sha512-HWLJhc+ePBShvCuslyW5zDaqMaY+czNijqEEJI5eiYBblNJbt+onKZhoExpd2JTTFgA1XImDI64oBSPjdTJz/g==}
-    dependencies:
-      bip39: 3.0.4
-      crypto-js: 3.3.0
-      hypercore-crypto: 2.3.2
-
   /@dxos/crypto/2.23.0:
     resolution: {integrity: sha512-rhje4hQmWJiXa7lPFum9ZmvE6phRPjszLGgDmQlunNC0ePZIeqJSDYkgSjuny0udbKr58AV6nPMsqY6ULaIUKw==}
     dependencies:
       bip39: 3.0.4
       crypto-js: 3.3.0
       hypercore-crypto: 2.3.2
-
-  /@dxos/debug/2.22.0:
-    resolution: {integrity: sha512-23ZZrSj3ct3daTuvW3cwMUiiF4actRt9CZQbACnh0isQ7RSzKsLrWbUnmrRsCIYfIHco0un3aetgNOjytGUxbQ==}
-    dependencies:
-      '@types/node': 14.18.1
-      debug: 4.3.3
-    transitivePeerDependencies:
-      - supports-color
 
   /@dxos/debug/2.23.0:
     resolution: {integrity: sha512-ActrCbKJ+kSoLLNYtBeA2oAlUgDDqXe6h92hqDUvqEsS6tSJpWhdHKNEXniVR1maCMvQS8dj1JlJ+uo9w5nxNg==}
@@ -1649,18 +1634,18 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@dxos/eslint-plugin/1.0.20_eslint@7.32.0+typescript@4.5.4:
-    resolution: {integrity: sha512-zFQi4ooCoatZmz5L4Ei1HOqFosi/+LrxMkrKx6HjZjJpPxYpAZ2EgCjUmg/JHhcMWelNhikQHTeZqBkI1yzQqg==}
+  /@dxos/eslint-plugin/1.0.21_eslint@7.32.0+typescript@4.5.4:
+    resolution: {integrity: sha512-j1EzU6qK0BoMlQDzRCBq2IYKFnh7YRdZfKPOf/qcXnIb2VFC7klcUasx/5y/F7aoxCw+ErN5pxEBrNQ7IhVsVQ==}
     peerDependencies:
       typescript: '*'
     dependencies:
       '@rushstack/eslint-patch': 1.1.0
-      '@typescript-eslint/eslint-plugin': 4.33.0_3289a875d95a672b97ebf589745c66ef
-      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.4
+      '@typescript-eslint/eslint-plugin': 5.10.1_66fd760357c363ad2580db2ecc311e20
+      '@typescript-eslint/parser': 5.10.1_eslint@7.32.0+typescript@4.5.4
       eslint-config-semistandard: 16.0.0_f40c7c316f5b2a5b4e5798a87f2a2fe7
       eslint-config-standard: 16.0.3_d42fecbad7bfe7f5a4cd1039746899f1
       eslint-plugin-import: 2.25.3_eslint@7.32.0
-      eslint-plugin-jest: 24.7.0_f42847b8cf886233a5558f157bd21430
+      eslint-plugin-jest: 24.7.0_f8c50dc31f015940afb4e41b6b64f409
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-promise: 5.2.0_eslint@7.32.0
       eslint-plugin-standard: 5.0.0_eslint@7.32.0
@@ -1926,15 +1911,6 @@ packages:
       - utf-8-validate
       - winston
     dev: true
-
-  /@dxos/util/2.22.0:
-    resolution: {integrity: sha512-aQU9dW+7KLzx4pKxshCCXf2stBTpk6sjtGrear8uqkRI64MgszYh/WYATpVybrogFRtXgqvdXgnvMW50HQq2Cw==}
-    dependencies:
-      '@dxos/crypto': 2.22.0
-      '@dxos/debug': 2.22.0
-      '@types/node': 14.18.1
-    transitivePeerDependencies:
-      - supports-color
 
   /@dxos/util/2.23.0:
     resolution: {integrity: sha512-f2gTNdeemr/rnKt8xhIHF1mn56xn9nUD9gqYfi9u3QliqM29RX8fN0deDowUzWOWFACNMK9vq8T1Ds2Km8taSQ==}
@@ -3327,20 +3303,21 @@ packages:
     dependencies:
       '@types/yargs-parser': 20.2.1
 
-  /@typescript-eslint/eslint-plugin/4.33.0_3289a875d95a672b97ebf589745c66ef:
-    resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/eslint-plugin/5.10.1_66fd760357c363ad2580db2ecc311e20:
+    resolution: {integrity: sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^4.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0+typescript@4.5.4
-      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.5.4
-      '@typescript-eslint/scope-manager': 4.33.0
+      '@typescript-eslint/parser': 5.10.1_eslint@7.32.0+typescript@4.5.4
+      '@typescript-eslint/scope-manager': 5.10.1
+      '@typescript-eslint/type-utils': 5.10.1_eslint@7.32.0+typescript@4.5.4
+      '@typescript-eslint/utils': 5.10.1_eslint@7.32.0+typescript@4.5.4
       debug: 4.3.3
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
@@ -3371,19 +3348,19 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_eslint@7.32.0+typescript@4.5.4:
-    resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@typescript-eslint/parser/5.10.1_eslint@7.32.0+typescript@4.5.4:
+    resolution: {integrity: sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 4.33.0
-      '@typescript-eslint/types': 4.33.0
-      '@typescript-eslint/typescript-estree': 4.33.0_typescript@4.5.4
+      '@typescript-eslint/scope-manager': 5.10.1
+      '@typescript-eslint/types': 5.10.1
+      '@typescript-eslint/typescript-estree': 5.10.1_typescript@4.5.4
       debug: 4.3.3
       eslint: 7.32.0
       typescript: 4.5.4
@@ -3399,9 +3376,41 @@ packages:
       '@typescript-eslint/visitor-keys': 4.33.0
     dev: true
 
+  /@typescript-eslint/scope-manager/5.10.1:
+    resolution: {integrity: sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.10.1
+      '@typescript-eslint/visitor-keys': 5.10.1
+    dev: true
+
+  /@typescript-eslint/type-utils/5.10.1_eslint@7.32.0+typescript@4.5.4:
+    resolution: {integrity: sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/utils': 5.10.1_eslint@7.32.0+typescript@4.5.4
+      debug: 4.3.3
+      eslint: 7.32.0
+      tsutils: 3.21.0_typescript@4.5.4
+      typescript: 4.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/types/4.33.0:
     resolution: {integrity: sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
+    dev: true
+
+  /@typescript-eslint/types/5.10.1:
+    resolution: {integrity: sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree/4.33.0_typescript@4.5.4:
@@ -3425,12 +3434,59 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.10.1_typescript@4.5.4:
+    resolution: {integrity: sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.10.1
+      '@typescript-eslint/visitor-keys': 5.10.1
+      debug: 4.3.3
+      globby: 11.0.4
+      is-glob: 4.0.3
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.5.4
+      typescript: 4.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.10.1_eslint@7.32.0+typescript@4.5.4:
+    resolution: {integrity: sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.10.1
+      '@typescript-eslint/types': 5.10.1
+      '@typescript-eslint/typescript-estree': 5.10.1_typescript@4.5.4
+      eslint: 7.32.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@7.32.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/visitor-keys/4.33.0:
     resolution: {integrity: sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dependencies:
       '@typescript-eslint/types': 4.33.0
       eslint-visitor-keys: 2.1.0
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.10.1:
+    resolution: {integrity: sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.10.1
+      eslint-visitor-keys: 3.2.0
     dev: true
 
   /@ungap/promise-all-settled/1.1.2:
@@ -5466,7 +5522,7 @@ packages:
       tsconfig-paths: 3.12.0
     dev: true
 
-  /eslint-plugin-jest/24.7.0_f42847b8cf886233a5558f157bd21430:
+  /eslint-plugin-jest/24.7.0_f8c50dc31f015940afb4e41b6b64f409:
     resolution: {integrity: sha512-wUxdF2bAZiYSKBclsUMrYHH6WxiBreNjyDxbRv345TIvPeoCEgPNEn3Sa+ZrSqsf1Dl9SqqSREXMHExlMMu1DA==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -5476,7 +5532,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0_3289a875d95a672b97ebf589745c66ef
+      '@typescript-eslint/eslint-plugin': 5.10.1_66fd760357c363ad2580db2ecc311e20
       '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0+typescript@4.5.4
       eslint: 7.32.0
     transitivePeerDependencies:
@@ -5550,6 +5606,11 @@ packages:
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-visitor-keys/3.2.0:
+    resolution: {integrity: sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /eslint/7.32.0:

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "test": "jest --rootDir ./assets/content --passWithNoTests"
   },
   "dependencies": {
-    "@dxos/docs-theme": "^1.0.0-beta.22",
+    "@dxos/docs-theme": "^1.0.0-beta.23",
     "gatsby": "^2.17.11",
     "gatsby-plugin-sharp": "^2.6.14",
     "gatsby-source-filesystem": "^2.3.14",

--- a/packages/cli-app/package.json
+++ b/packages/cli-app/package.json
@@ -42,7 +42,7 @@
     "@dxos/cli-core": "workspace:*",
     "@dxos/debug": "~2.23.0",
     "@dxos/registry-client": "~2.23.0",
-    "@dxos/util": "^2.15.6",
+    "@dxos/util": "^2.23.0",
     "@otplib/plugin-thirty-two": "^12.0.1",
     "@polkadot/api": "4.17.1",
     "assert": "^2.0.0",
@@ -78,7 +78,7 @@
     "debug": "~4.3.3"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "@types/body-parser": "^1.19.1",
     "@types/cli-progress": "^3.9.2",
     "@types/cookie-parser": "^1.4.2",

--- a/packages/cli-bot/package.json
+++ b/packages/cli-bot/package.json
@@ -40,7 +40,7 @@
     "@dxos/crypto": "~2.23.0",
     "@dxos/debug": "~2.23.0",
     "@dxos/registry-client": "~2.23.0",
-    "@dxos/util": "^2.15.6",
+    "@dxos/util": "^2.23.0",
     "assert": "^2.0.0",
     "chance": "^1.1.3",
     "envfile": "^6.17.0",
@@ -60,7 +60,7 @@
     "@dxos/bot-factory-client": "~2.23.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-chat/package.json
+++ b/packages/cli-chat/package.json
@@ -46,7 +46,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-console/package.json
+++ b/packages/cli-console/package.json
@@ -54,7 +54,7 @@
     "abort-controller": "~3.0.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-core/package.json
+++ b/packages/cli-core/package.json
@@ -70,7 +70,7 @@
     "@dxos/async": "~2.23.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "@types/dockerode": "^3.2.3",
     "@types/download": "^6.2.4",
     "@types/fs-extra": "^9.0.13",

--- a/packages/cli-data/package.json
+++ b/packages/cli-data/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@dxos/async": "~2.23.0",
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "@dxos/signal": "~2.23.0",
     "@types/lockfile": "^1.0.2",
     "eslint": "^7.13.0",

--- a/packages/cli-dxns/package.json
+++ b/packages/cli-dxns/package.json
@@ -64,7 +64,7 @@
     "abort-controller": "~3.0.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-jest": "^27.0.0",

--- a/packages/cli-echo/package.json
+++ b/packages/cli-echo/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@dxos/cli-data": "workspace:*",
     "@dxos/echo-db": "~2.23.0",
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-halo/package.json
+++ b/packages/cli-halo/package.json
@@ -43,7 +43,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-ipfs/package.json
+++ b/packages/cli-ipfs/package.json
@@ -57,7 +57,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-kube/package.json
+++ b/packages/cli-kube/package.json
@@ -52,7 +52,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-jest": "^27.0.0",

--- a/packages/cli-mdns/package.json
+++ b/packages/cli-mdns/package.json
@@ -40,7 +40,7 @@
     "assert": "^2.0.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-mesh/package.json
+++ b/packages/cli-mesh/package.json
@@ -45,7 +45,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-pad/package.json
+++ b/packages/cli-pad/package.json
@@ -50,7 +50,7 @@
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "eslint": "^7.13.0",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",

--- a/packages/cli-signal/package.json
+++ b/packages/cli-signal/package.json
@@ -41,7 +41,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "jest": "^27.4.4",
     "ts-node": "^10.2.1",
     "typescript": "^4.0.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,7 +67,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "jest": "^27.4.4",
     "json2yaml": "^1.1.0",
     "ts-node": "^10.2.1",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -17,7 +17,7 @@
     "bail": true
   },
   "devDependencies": {
-    "@dxos/eslint-plugin": "~1.0.20",
+    "@dxos/eslint-plugin": "~1.0.21",
     "@types/expect": "^24.3.0",
     "@types/mocha": "^9.0.0",
     "eslint": "^7.13.0",
@@ -37,7 +37,7 @@
     "@dxos/async": "~2.23.0",
     "@dxos/cli-core": "workspace:*",
     "@dxos/signal": "~2.23.0",
-    "@dxos/util": "^2.15.6",
+    "@dxos/util": "^2.23.0",
     "sodium-universal": "~3.0.4",
     "sodium-native": "~3.3.0",
     "ws": "~8.4.2",


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/dxos/cli/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc</em></summary>



</details>
<details>
<summary><em>cli.js -u --deep '@dxos/*'</em></summary>

```Shell
Upgrading /home/runner/work/cli/cli/package.json

No dependencies.
Upgrading /home/runner/work/cli/cli/docs/package.json

 @dxos/docs-theme  ^1.0.0-beta.22  →  ^1.0.0-beta.23     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-app/package.json

 @dxos/util           ^2.15.6  →  ^2.23.0     
 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-bot/package.json

 @dxos/util           ^2.15.6  →  ^2.23.0     
 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-chat/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-console/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-core/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-data/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-dxns/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-echo/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-halo/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-ipfs/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-kube/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-mdns/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-mesh/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-pad/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/cli-signal/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/e2e/package.json

 @dxos/eslint-plugin  ~1.0.20  →  ~1.0.21     
 @dxos/util           ^2.15.6  →  ^2.23.0     

Run npm install to install new versions.

Upgrading /home/runner/work/cli/cli/packages/e2e/mocks/app/package.json

No dependencies.
Upgrading /home/runner/work/cli/cli/packages/e2e/mocks/dxns/app/package.json

No dependencies.
```



</details>
<details>
<summary><em>npm install -g @microsoft/rush pnpm</em></summary>

```Shell
added 290 packages, and audited 291 packages in 12s

33 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

### stderr:

```Shell
npm WARN deprecated read-package-tree@5.1.6: The functionality that this package provided is now in @npmcli/arborist
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated @opentelemetry/types@0.2.0: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
```

</details>
<details>
<summary><em>node common/scripts/install-run-rush.js update</em></summary>

```Shell
The rush.json configuration requests Rush version 5.58.0
Transforming /home/runner/work/cli/cli/common/config/rush/.npmrc
  --> "/home/runner/work/cli/cli/common/temp/install-run/@microsoft+rush@5.58.0/.npmrc"
Installing @microsoft/rush...

added 286 packages, and audited 287 packages in 5s

32 packages are looking for funding
  run `npm fund` for details

4 high severity vulnerabilities

To address all issues, run:
  npm audit fix --force

Run `npm audit` for details.
Successfully installed @microsoft/rush@5.58.0

Invoking "rush update"
----------------------



Rush Multi-Project Build Tool 5.58.0 - https://rushjs.io
Node.js version is 16.1.0 (pre-LTS)


Starting "rush update"

Creating /home/runner/.rush/node-v16.1.0
Trying to acquire lock for pnpm-6.24.2
Acquired lock for pnpm-6.24.2
Installing pnpm version 6.24.2

Transforming /home/runner/work/cli/cli/common/config/rush/.npmrc
  --> "/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/.npmrc"

Running "npm install" in /home/runner/.rush/node-v16.1.0/pnpm-6.24.2

added 1 package, and audited 2 packages in 673ms

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Successfully installed pnpm version 6.24.2

Symlinking "/home/runner/work/cli/cli/common/temp/pnpm-local"
  --> "/home/runner/.rush/node-v16.1.0/pnpm-6.24.2"

Using the default variant for installation.
Transforming /home/runner/work/cli/cli/common/config/rush/.npmrc
  --> "/home/runner/work/cli/cli/common/temp/.npmrc"

Updating workspace files in /home/runner/work/cli/cli/common/temp
Copying "/home/runner/work/cli/cli/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/cli/cli/common/temp/pnpm-lock.yaml"
Copying "/home/runner/work/cli/cli/common/config/rush/pnpm-lock.yaml"
  --> "/home/runner/work/cli/cli/common/temp/pnpm-lock-preinstall.yaml"

The shrinkwrap file contains the following issues:
  Dependencies of project "@dxos/cli" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-app" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-bot" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-chat" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-console" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-core" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-data" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-dxns" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-e2e-test" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-echo" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-halo" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-ipfs" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-kube" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-mdns" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-mesh" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-pad" do not match the current shrinkwrap.
  Dependencies of project "@dxos/cli-signal" do not match the current shrinkwrap.


Checking installation in "/home/runner/work/cli/cli/common/temp"


Running "pnpm install" in /home/runner/work/cli/cli/common/temp

Scope: all 18 workspace projects
Progress: resolved 1, reused 0, downloaded 0, added 0
../../packages/cli-core                  |  WARN  deprecated node-pre-gyp@0.13.0
Progress: resolved 70, reused 0, downloaded 64, added 0
../../packages/e2e                       |  WARN  deprecated @types/expect@24.3.0
Progress: resolved 116, reused 0, downloaded 108, added 0
../../packages/cli-core                  |  WARN  deprecated lodash.isarray@4.0.0
../../packages/cli                       |  WARN  deprecated lodash.isarray@4.0.0
../../packages/cli-chat                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-console               |  WARN  deprecated uuid@3.4.0
../../packages/cli-data                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-dxns                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-halo                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-ipfs                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-kube                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-mdns                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-mesh                  |  WARN  deprecated uuid@3.4.0
../../packages/cli-app                   |  WARN  deprecated uuid@3.4.0
../../packages/cli-bot                   |  WARN  deprecated uuid@3.4.0
../../packages/cli-echo                  |  WARN  deprecated uuid@3.4.0
Progress: resolved 175, reused 0, downloaded 165, added 0
Progress: resolved 288, reused 0, downloaded 277, added 0
Progress: resolved 441, reused 0, downloaded 433, added 0
Progress: resolved 583, reused 0, downloaded 573, added 0
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /home/runner/work/cli/cli/common/temp/pnpm-store/v3
  Virtual store is at:             node_modules/.pnpm
Progress: resolved 658, reused 0, downloaded 640, added 0
Progress: resolved 728, reused 0, downloaded 710, added 0
Progress: resolved 813, reused 0, downloaded 795, added 0
Progress: resolved 960, reused 0, downloaded 935, added 0
Progress: resolved 1111, reused 0, downloaded 1087, added 0
Progress: resolved 1272, reused 0, downloaded 1255, added 0
Progress: resolved 1366, reused 0, downloaded 1348, added 0
Progress: resolved 1457, reused 0, downloaded 1430, added 0
Progress: resolved 1546, reused 0, downloaded 1543, added 0
Progress: resolved 1552, reused 0, downloaded 1543, added 0
.                                        |    +1551 ++++++++++++++++++++++++++++
Progress: resolved 1552, reused 0, downloaded 1548, added 111
Progress: resolved 1552, reused 0, downloaded 1549, added 1035
Progress: resolved 1552, reused 0, downloaded 1549, added 1549
.../node_modules/cpu-features install$ node-gyp rebuild
.../core-js@2.6.12/node_modules/core-js postinstall$ node -e "try{require('./postinstall')}catch(e){}"
.../esbuild@0.11.23/node_modules/esbuild postinstall$ node install.js
.../node_modules/bufferutil install$ node-gyp-build
Progress: resolved 1552, reused 0, downloaded 1551, added 1551, done
.../.pnpm/fsctl@1.0.0/node_modules/fsctl install$ node-gyp-build
.../node_modules/cpu-features install: gyp info it worked if it ends with ok
.../node_modules/cpu-features install: gyp info using node-gyp@8.4.1
.../node_modules/cpu-features install: gyp info using node@16.1.0 | linux | x64
.../core-js@2.6.12/node_modules/core-js postinstall: Done
.../node_modules/iso-constants install$ node build.js > index.browser.js
.../node_modules/bufferutil install: Done
.../node_modules/leveldown install$ node-gyp-build
.../node_modules/cpu-features install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/iso-constants install: Done
.../node_modules/protobufjs postinstall$ node scripts/postinstall
.../.pnpm/fsctl@1.0.0/node_modules/fsctl install: Done
.../node_modules/secp256k1 install$ npm run rebuild || echo "Secp256k1 bindings compilation fail. Pure JS implementation will be used."
.../node_modules/protobufjs postinstall: Done
.../node_modules/sodium-native install$ node-gyp-build "node preinstall.js" "node postinstall.js"
.../node_modules/cpu-features install: gyp http GET https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../node_modules/leveldown install: Done
.../node_modules/sodium-native install$ node-gyp-build
.../node_modules/cpu-features install: gyp http 200 https://nodejs.org/download/release/v16.1.0/node-v16.1.0-headers.tar.gz
.../node_modules/sodium-native install: Done
.../node_modules/tiny-secp256k1 install$ npm run build || echo "secp256k1 bindings compilation fail. Pure JS implementation will be used."
.../node_modules/secp256k1 install: > secp256k1@3.8.0 rebuild
.../node_modules/secp256k1 install: > node-gyp rebuild
.../node_modules/secp256k1 install: gyp info it worked if it ends with ok
.../node_modules/secp256k1 install: gyp info using node-gyp@7.1.2
.../node_modules/secp256k1 install: gyp info using node@16.1.0 | linux | x64
.../node_modules/tiny-secp256k1 install: > tiny-secp256k1@1.1.6 build
.../node_modules/tiny-secp256k1 install: > node-gyp rebuild
.../node_modules/cpu-features install: gyp http GET https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../node_modules/sodium-native install: autoreconf: Entering directory `.'
.../node_modules/sodium-native install: autoreconf: configure.ac: not using Gettext
.../node_modules/cpu-features install: gyp http 200 https://nodejs.org/download/release/v16.1.0/SHASUMS256.txt
.../node_modules/secp256k1 install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/cpu-features install: gyp info spawn /usr/bin/python3
.../node_modules/cpu-features install: gyp info spawn args [
.../node_modules/cpu-features install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/cpu-features install: gyp info spawn args   'binding.gyp',
.../node_modules/cpu-features install: gyp info spawn args   '-f',
.../node_modules/cpu-features install: gyp info spawn args   'make',
.../node_modules/cpu-features install: gyp info spawn args   '-I',
.../node_modules/cpu-features install: gyp info spawn args   '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/build/config.gypi',
.../node_modules/cpu-features install: gyp info spawn args   '-I',
.../node_modules/cpu-features install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../node_modules/cpu-features install: gyp info spawn args   '-I',
.../node_modules/cpu-features install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/cpu-features install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/cpu-features install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/cpu-features install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/cpu-features install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp',
.../node_modules/cpu-features install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/cpu-features install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features',
.../node_modules/cpu-features install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/cpu-features install: gyp info spawn args   '--depth=.',
.../node_modules/cpu-features install: gyp info spawn args   '--no-parallel',
.../node_modules/cpu-features install: gyp info spawn args   '--generator-output',
.../node_modules/cpu-features install: gyp info spawn args   'build',
.../node_modules/cpu-features install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/cpu-features install: gyp info spawn args ]
.../esbuild@0.11.23/node_modules/esbuild postinstall: Done
.../node_modules/utf-8-validate install$ node-gyp-build
.../node_modules/tiny-secp256k1 install: gyp info it worked if it ends with ok
.../node_modules/tiny-secp256k1 install: gyp info using node-gyp@7.1.2
.../node_modules/tiny-secp256k1 install: gyp info using node@16.1.0 | linux | x64
.../node_modules/secp256k1 install: (node:1958) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../node_modules/secp256k1 install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../node_modules/secp256k1 install: gyp info spawn /usr/bin/python3
.../node_modules/secp256k1 install: gyp info spawn args [
.../node_modules/secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/secp256k1 install: gyp info spawn args   'binding.gyp',
.../node_modules/secp256k1 install: gyp info spawn args   '-f',
.../node_modules/secp256k1 install: gyp info spawn args   'make',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build/config.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-I',
.../node_modules/secp256k1 install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1',
.../node_modules/secp256k1 install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/secp256k1 install: gyp info spawn args   '--depth=.',
.../node_modules/secp256k1 install: gyp info spawn args   '--no-parallel',
.../node_modules/secp256k1 install: gyp info spawn args   '--generator-output',
.../node_modules/secp256k1 install: gyp info spawn args   'build',
.../node_modules/secp256k1 install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/secp256k1 install: gyp info spawn args ]
.../node_modules/utf-8-validate install: Done
.../node_modules/utp-native install$ node-gyp-build
.../node_modules/cpu-features install: gyp info spawn make
.../node_modules/cpu-features install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/cpu-features install: make: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/build'
.../node_modules/cpu-features install:   ACTION Configuring dependencies /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build/Makefile
.../node_modules/tiny-secp256k1 install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/utp-native install: Done
.../node_modules/secp256k1 install: gyp info spawn make
.../node_modules/secp256k1 install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/secp256k1 install: make: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build'
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/addon.o
.../node_modules/tiny-secp256k1 install: (node:1989) [DEP0150] DeprecationWarning: Setting process.config is deprecated. In the future the property will be read-only.
.../node_modules/tiny-secp256k1 install: (Use `node --trace-deprecation ...` to show where the warning was created)
.../node_modules/tiny-secp256k1 install: gyp info spawn /usr/bin/python3
.../node_modules/tiny-secp256k1 install: gyp info spawn args [
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'binding.gyp',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-f',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'make',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build/config.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-I',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_gyp_dir=/opt/hostedtoolcache/node/16.1.0/x64/lib/node_modules/npm/node_modules/node-gyp',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--depth=.',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--no-parallel',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '--generator-output',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   'build',
.../node_modules/tiny-secp256k1 install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/tiny-secp256k1 install: gyp info spawn args ]
.../node_modules/cpu-features install: -- The C compiler identification is GNU 9.3.0
.../node_modules/cpu-features install: -- Detecting C compiler ABI info
.../node_modules/tiny-secp256k1 install: gyp info spawn make
.../node_modules/tiny-secp256k1 install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/tiny-secp256k1 install: make: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build'
.../node_modules/tiny-secp256k1 install:   CXX(target) Release/obj.target/secp256k1/native/addon.o
.../node_modules/cpu-features install: -- Detecting C compiler ABI info - done
.../node_modules/cpu-features install: -- Check for working C compiler: /usr/bin/cc - skipped
.../node_modules/cpu-features install: -- Detecting C compile features
.../node_modules/cpu-features install: -- Detecting C compile features - done
.../node_modules/cpu-features install: -- Looking for dlfcn.h
.../node_modules/sodium-native install: autoreconf: running: aclocal --force -I m4
.../node_modules/cpu-features install: -- Looking for dlfcn.h - found
.../node_modules/cpu-features install: -- Looking for getauxval
.../node_modules/cpu-features install: -- Looking for getauxval - found
.../node_modules/cpu-features install: -- Configuring done
.../node_modules/cpu-features install: -- Generating done
.../node_modules/cpu-features install: -- Build files have been written to: /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build
.../node_modules/cpu-features install:   TOUCH Release/obj.target/config_deps.stamp
.../node_modules/cpu-features install:   ACTION Building dependencies /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build/libcpu_features.a
.../node_modules/cpu-features install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [ 11%] Building C object CMakeFiles/utils.dir/src/filesystem.c.o
.../node_modules/tiny-secp256k1 install: In file included from ../../../../nan@2.15.0/node_modules/nan/nan.h:58,
.../node_modules/tiny-secp256k1 install:                  from ../native/addon.cpp:4:
.../node_modules/tiny-secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/tiny-secp256k1 install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/tiny-secp256k1 install:       |                                           ^
.../node_modules/tiny-secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/tiny-secp256k1 install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/tiny-secp256k1 install:       |   ^~~~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:372:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/tiny-secp256k1 install:   372 | NODE_MODULE(secp256k1, Init)
.../node_modules/tiny-secp256k1 install:       | ^~~~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&, const A&) [with long unsigned int index = 2; I = Nan::FunctionCallbackInfo<v8::Value>; A = v8::Local<v8::Object>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:151:50:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:80:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install:    80 |   if (info.Length() <= index || info[index]->IsUndefined()) {
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&, const A&) [with long unsigned int index = 1; I = Nan::FunctionCallbackInfo<v8::Value>; A = v8::Local<v8::Object>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:183:49:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:80:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In instantiation of ‘unsigned int {anonymous}::assumeCompression(const I&) [with long unsigned int index = 1; I = Nan::FunctionCallbackInfo<v8::Value>]’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:198:46:   required from here
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:92:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
.../node_modules/tiny-secp256k1 install:    92 |   if (info.Length() <= index) return SECP256K1_EC_COMPRESSED;
.../node_modules/cpu-features install: [ 22%] Building C object CMakeFiles/utils.dir/src/stack_line_reader.c.o
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp: In function ‘Nan::NAN_METHOD_RETURN_TYPE eccPrivateSub(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/tiny-secp256k1 install: ../native/addon.cpp:249:29: warning: ignoring return value of ‘int secp256k1_ec_privkey_negate(const secp256k1_context*, unsigned char*)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/tiny-secp256k1 install:   249 |  secp256k1_ec_privkey_negate(context, tweak_negated); // returns 1 always
.../node_modules/tiny-secp256k1 install:       |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
.../node_modules/cpu-features install: [ 33%] Building C object CMakeFiles/utils.dir/src/string_view.c.o
.../node_modules/secp256k1 install: In file included from ../src/addon.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/secp256k1 install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/secp256k1 install:       |                                           ^
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/secp256k1 install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/secp256k1 install:       |   ^~~~~~~~~~~~~
.../node_modules/secp256k1 install: ../src/addon.cc:50:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/secp256k1 install:    50 | NODE_MODULE(secp256k1, Init)
.../node_modules/secp256k1 install:       | ^~~~~~~~~~~
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [ 33%] Built target utils
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [ 44%] Building C object CMakeFiles/unix_based_hardware_detection.dir/src/hwcaps.c.o
.../node_modules/cpu-features install: [ 55%] Building C object CMakeFiles/unix_based_hardware_detection.dir/src/unix_features_aggregator.c.o
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [ 55%] Built target unix_based_hardware_detection
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [ 66%] Building C object CMakeFiles/cpu_features.dir/src/cpuinfo_x86.c.o
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/privatekey.o
.../node_modules/tiny-secp256k1 install:   CC(target) Release/obj.target/secp256k1/native/secp256k1/src/secp256k1.o
.../node_modules/cpu-features install: [ 77%] Linking C static library libcpu_features.a
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [ 77%] Built target cpu_features
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/tiny-secp256k1 install: In file included from ../native/secp256k1/src/assumptions.h:12,
.../node_modules/tiny-secp256k1 install:                  from ../native/secp256k1/src/secp256k1.c:10:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_context_preallocated_clone’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘prealloc’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:168:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   168 |     ARG_CHECK(prealloc != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_parse’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:283:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   283 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:285:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   285 |     ARG_CHECK(input != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_serialize’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:307:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   307 |     ARG_CHECK(output != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘outputlen’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:303:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   303 |     ARG_CHECK(outputlen != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:309:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   309 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_parse_der’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:348:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   348 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:349:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   349 |     ARG_CHECK(input != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_parse_compact’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:366:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   366 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘input64’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:367:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   367 |     ARG_CHECK(input64 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_serialize_der’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:385:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   385 |     ARG_CHECK(output != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘outputlen’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:386:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   386 |     ARG_CHECK(outputlen != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:387:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   387 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_serialize_compact’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘output64’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:397:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   397 |     ARG_CHECK(output64 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:398:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   398 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_signature_normalize’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sigin’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:411:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   411 |     ARG_CHECK(sigin != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_verify’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘sig’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:432:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   432 |     ARG_CHECK(sig != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘msg32’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:431:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   431 |     ARG_CHECK(msg32 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:433:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   433 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ecdsa_sign’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘signature’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:542:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   542 |     ARG_CHECK(signature != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘msg32’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:541:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   541 |     ARG_CHECK(msg32 != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:543:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   543 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_verify’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:554:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   554 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_create’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:578:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   578 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:581:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   581 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_negate’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:595:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   595 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_negate’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:614:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   614 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_tweak_add’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:641:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   641 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:642:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   642 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_tweak_add’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:669:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   669 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:670:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   670 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_seckey_tweak_mul’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘seckey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:688:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   688 |     ARG_CHECK(seckey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:689:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   689 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_tweak_mul’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubkey’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:713:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   713 |     ARG_CHECK(pubkey != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘tweak’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:714:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   714 |     ARG_CHECK(tweak != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c: In function ‘secp256k1_ec_pubkey_combine’:
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubnonce’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:743:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   743 |     ARG_CHECK(pubnonce != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:30:16: warning: nonnull argument ‘pubnonces’ compared to NULL [-Wnonnull-compare]
.../node_modules/tiny-secp256k1 install:    30 |     if (EXPECT(!(cond), 0)) { \
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/util.h:41:39: note: in definition of macro ‘EXPECT’
.../node_modules/tiny-secp256k1 install:    41 | #define EXPECT(x,c) __builtin_expect((x),(c))
.../node_modules/tiny-secp256k1 install:       |                                       ^
.../node_modules/tiny-secp256k1 install: ../native/secp256k1/src/secp256k1.c:746:5: note: in expansion of macro ‘ARG_CHECK’
.../node_modules/tiny-secp256k1 install:   746 |     ARG_CHECK(pubnonces != NULL);
.../node_modules/tiny-secp256k1 install:       |     ^~~~~~~~~
.../node_modules/cpu-features install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [ 88%] Building C object CMakeFiles/list_cpu_features.dir/src/utils/list_cpu_features.c.o
.../node_modules/cpu-features install: [100%] Linking C executable list_cpu_features
.../node_modules/cpu-features install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: [100%] Built target list_cpu_features
.../node_modules/cpu-features install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/deps/cpu_features/build'
.../node_modules/cpu-features install:   TOUCH Release/obj.target/build_deps.stamp
.../node_modules/cpu-features install:   CXX(target) Release/obj.target/cpufeatures/src/binding.o
.../node_modules/secp256k1 install: ../src/privatekey.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE privateKeyNegate(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/secp256k1 install: ../src/privatekey.cc:73:30: warning: ignoring return value of ‘int secp256k1_ec_privkey_negate(const secp256k1_context*, unsigned char*)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    73 |   secp256k1_ec_privkey_negate(secp256k1ctx, &private_key[0]);
.../node_modules/secp256k1 install:       |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: autoreconf: configure.ac: tracing
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/publickey.o
.../node_modules/cpu-features install: In file included from ../src/binding.cc:1:
.../node_modules/cpu-features install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/cpu-features install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/cpu-features install:       |                                           ^
.../node_modules/cpu-features install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/cpu-features install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/cpu-features install:       |   ^~~~~~~~~~~~~
.../node_modules/cpu-features install: ../src/binding.cc:153:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/cpu-features install:   153 | NODE_MODULE(cpufeatures, init)
.../node_modules/cpu-features install:       | ^~~~~~~~~~~
.../node_modules/cpu-features install:   SOLINK_MODULE(target) Release/obj.target/cpufeatures.node
.../node_modules/cpu-features install:   COPY Release/cpufeatures.node
.../node_modules/cpu-features install: make: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/cpu-features@0.0.2/node_modules/cpu-features/build'
.../node_modules/cpu-features install: gyp info ok 
.../node_modules/cpu-features install: Done
.../node_modules/sodium-native install: autoreconf: configure.ac: creating directory build-aux
.../node_modules/sodium-native install: autoreconf: running: libtoolize --copy --force
.../node_modules/tiny-secp256k1 install:   SOLINK_MODULE(target) Release/obj.target/secp256k1.node
.../node_modules/tiny-secp256k1 install:   COPY Release/secp256k1.node
.../node_modules/tiny-secp256k1 install: make: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/tiny-secp256k1@1.1.6/node_modules/tiny-secp256k1/build'
.../node_modules/tiny-secp256k1 install: gyp info ok 
.../node_modules/tiny-secp256k1 install: Done
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/signature.o
.../node_modules/sodium-native install: libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
.../node_modules/sodium-native install: libtoolize: copying file 'build-aux/ltmain.sh'
.../node_modules/sodium-native install: libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
.../node_modules/sodium-native install: libtoolize: copying file 'm4/libtool.m4'
.../node_modules/sodium-native install: libtoolize: copying file 'm4/ltoptions.m4'
.../node_modules/sodium-native install: libtoolize: copying file 'm4/ltsugar.m4'
.../node_modules/sodium-native install: libtoolize: copying file 'm4/ltversion.m4'
.../node_modules/sodium-native install: libtoolize: copying file 'm4/lt~obsolete.m4'
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/ecdsa.o
.../node_modules/secp256k1 install: ../src/ecdsa.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sign(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/secp256k1 install: ../src/ecdsa.cc:88:131: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    88 |   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("signature").ToLocalChecked(), COPY_BUFFER(&output[0], 64));
.../node_modules/secp256k1 install:       |                                                                                                                                   ^
.../node_modules/secp256k1 install: In file included from /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:63,
.../node_modules/secp256k1 install:                  from ../src/ecdsa.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/v8.h:3926:37: note: declared here
.../node_modules/secp256k1 install:  3926 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
.../node_modules/secp256k1 install:       |                                     ^~~
.../node_modules/secp256k1 install: ../src/ecdsa.cc:89:130: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
.../node_modules/secp256k1 install:    89 |   obj->Set(info.GetIsolate()->GetCurrentContext(), Nan::New<v8::String>("recovery").ToLocalChecked(), Nan::New<v8::Number>(recid));
.../node_modules/secp256k1 install:       |                                                                                                                                  ^
.../node_modules/secp256k1 install: In file included from /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:63,
.../node_modules/secp256k1 install:                  from ../src/ecdsa.cc:1:
.../node_modules/secp256k1 install: /home/runner/.cache/node-gyp/16.1.0/include/node/v8.h:3926:37: note: declared here
.../node_modules/secp256k1 install:  3926 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
.../node_modules/secp256k1 install:       |                                     ^~~
.../node_modules/secp256k1 install:   CXX(target) Release/obj.target/secp256k1/src/ecdh.o
.../node_modules/sodium-native install: autoreconf: running: /usr/bin/autoconf --force
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/src/secp256k1.o
.../node_modules/sodium-native install: autoreconf: configure.ac: not using Autoheader
.../node_modules/sodium-native install: autoreconf: running: automake --add-missing --copy --force-missing
.../node_modules/sodium-native install: configure.ac:74: installing 'build-aux/compile'
.../node_modules/sodium-native install: configure.ac:9: installing 'build-aux/config.guess'
.../node_modules/sodium-native install: configure.ac:9: installing 'build-aux/config.sub'
.../node_modules/sodium-native install: configure.ac:10: installing 'build-aux/install-sh'
.../node_modules/sodium-native install: configure.ac:10: installing 'build-aux/missing'
.../node_modules/sodium-native install: src/libsodium/Makefile.am: installing 'build-aux/depcomp'
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/contrib/lax_der_parsing.o
.../node_modules/sodium-native install: parallel-tests: installing 'build-aux/test-driver'
.../node_modules/secp256k1 install:   CC(target) Release/obj.target/secp256k1/src/secp256k1-src/contrib/lax_der_privatekey_parsing.o
.../node_modules/sodium-native install: autoreconf: Leaving directory `.'
.../node_modules/secp256k1 install:   SOLINK_MODULE(target) Release/obj.target/secp256k1.node
.../node_modules/secp256k1 install:   COPY Release/secp256k1.node
.../node_modules/secp256k1 install: make: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/secp256k1@3.8.0/node_modules/secp256k1/build'
.../node_modules/secp256k1 install: gyp info ok 
.../node_modules/secp256k1 install: Done
.../node_modules/sodium-native install: checking build system type... x86_64-pc-linux-gnu
.../node_modules/sodium-native install: checking host system type... x86_64-pc-linux-gnu
.../node_modules/sodium-native install: checking for a BSD-compatible install... /usr/bin/install -c
.../node_modules/sodium-native install: checking whether build environment is sane... yes
.../node_modules/sodium-native install: checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
.../node_modules/sodium-native install: checking for gawk... gawk
.../node_modules/sodium-native install: checking whether make sets $(MAKE)... yes
.../node_modules/sodium-native install: checking whether make supports nested variables... yes
.../node_modules/sodium-native install: checking whether UID '1001' is supported by ustar format... yes
.../node_modules/sodium-native install: checking whether GID '121' is supported by ustar format... yes
.../node_modules/sodium-native install: checking how to create a ustar tar archive... gnutar
.../node_modules/sodium-native install: checking whether make supports nested variables... (cached) yes
.../node_modules/sodium-native install: checking whether to enable maintainer-specific portions of Makefiles... no
.../node_modules/sodium-native install: checking whether make supports the include directive... yes (GNU style)
.../node_modules/sodium-native install: checking for gcc... gcc
.../node_modules/sodium-native install: checking whether the C compiler works... yes
.../node_modules/sodium-native install: checking for C compiler default output file name... a.out
.../node_modules/sodium-native install: checking for suffix of executables... 
.../node_modules/sodium-native install: checking whether we are cross compiling... no
.../node_modules/sodium-native install: checking for suffix of object files... o
.../node_modules/sodium-native install: checking whether we are using the GNU C compiler... yes
.../node_modules/sodium-native install: checking whether gcc accepts -g... yes
.../node_modules/sodium-native install: checking for gcc option to accept ISO C89... none needed
.../node_modules/sodium-native install: checking whether gcc understands -c and -o together... yes
.../node_modules/sodium-native install: checking dependency style of gcc... gcc3
.../node_modules/sodium-native install: checking for a sed that does not truncate output... /usr/bin/sed
.../node_modules/sodium-native install: checking how to run the C preprocessor... gcc -E
.../node_modules/sodium-native install: checking for grep that handles long lines and -e... /usr/bin/grep
.../node_modules/sodium-native install: checking for egrep... /usr/bin/grep -E
.../node_modules/sodium-native install: checking whether gcc is Clang... no
.../node_modules/sodium-native install: checking whether pthreads work with -pthread... yes
.../node_modules/sodium-native install: checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
.../node_modules/sodium-native install: checking whether more special flags are required for pthreads... no
.../node_modules/sodium-native install: checking for PTHREAD_PRIO_INHERIT... yes
.../node_modules/sodium-native install: checking for gcc option to accept ISO C99... none needed
.../node_modules/sodium-native install: checking dependency style of gcc... gcc3
.../node_modules/sodium-native install: checking for ANSI C header files... yes
.../node_modules/sodium-native install: checking for sys/types.h... yes
.../node_modules/sodium-native install: checking for sys/stat.h... yes
.../node_modules/sodium-native install: checking for stdlib.h... yes
.../node_modules/sodium-native install: checking for string.h... yes
.../node_modules/sodium-native install: checking for memory.h... yes
.../node_modules/sodium-native install: checking for strings.h... yes
.../node_modules/sodium-native install: checking for inttypes.h... yes
.../node_modules/sodium-native install: checking for stdint.h... yes
.../node_modules/sodium-native install: checking for unistd.h... yes
.../node_modules/sodium-native install: checking minix/config.h usability... no
.../node_modules/sodium-native install: checking minix/config.h presence... no
.../node_modules/sodium-native install: checking for minix/config.h... no
.../node_modules/sodium-native install: checking whether it is safe to define __EXTENSIONS__... yes
.../node_modules/sodium-native install: checking for variable-length arrays... yes
.../node_modules/sodium-native install: checking for __native_client__ defined... no
.../node_modules/sodium-native install: checking for _FORTIFY_SOURCE defined... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fvisibility=hidden... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fPIC... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fPIE... yes
.../node_modules/sodium-native install: checking whether the linker accepts -pie... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fno-strict-aliasing... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fno-strict-overflow... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -fstack-protector... yes
.../node_modules/sodium-native install: checking whether the linker accepts -fstack-protector... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wall... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra... yes
.../node_modules/sodium-native install: checking for clang... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wshorten-64-to-32... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wsometimes-uninitialized... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes -Wswitch-enum... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes -Wswitch-enum -Wvariable-decl... no
.../node_modules/sodium-native install: checking whether C compiler accepts -g -O2 -pthread -fvisibility=hidden -fPIC -fPIE -fno-strict-aliasing -fno-strict-overflow -fstack-protector -Wextra -Wbad-function-cast -Wcast-qual -Wdiv-by-zero -Wduplicated-branches -Wduplicated-cond -Wfloat-equal -Wformat=2 -Wlogical-op -Wmaybe-uninitialized -Wmisleading-indentation -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wno-type-limits -Wno-unknown-pragmas -Wnormalized=id -Wnull-dereference -Wold-style-declaration -Wpointer-arith -Wredundant-decls -Wrestrict -Wstrict-prototypes -Wswitch-enum -Wwrite-strings... yes
.../node_modules/sodium-native install: checking whether the linker accepts -Wl,-z,relro... yes
.../node_modules/sodium-native install: checking whether the linker accepts -Wl,-z,now... yes
.../node_modules/sodium-native install: checking whether the linker accepts -Wl,-z,noexecstack... yes
.../node_modules/sodium-native install: checking whether segmentation violations can be caught when using the C compiler... yes
.../node_modules/sodium-native install: checking whether SIGABRT can be caught when using the C compiler... yes
.../node_modules/sodium-native install: checking for thread local storage (TLS) class... _Thread_local
.../node_modules/sodium-native install: thread local storage is supported
.../node_modules/sodium-native install: checking whether C compiler accepts -ftls-model=local-dynamic... yes
.../node_modules/sodium-native install: checking how to print strings... printf
.../node_modules/sodium-native install: checking for a sed that does not truncate output... (cached) /usr/bin/sed
.../node_modules/sodium-native install: checking for fgrep... /usr/bin/grep -F
.../node_modules/sodium-native install: checking for ld used by gcc... /usr/bin/ld
.../node_modules/sodium-native install: checking if the linker (/usr/bin/ld) is GNU ld... yes
.../node_modules/sodium-native install: checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
.../node_modules/sodium-native install: checking the name lister (/usr/bin/nm -B) interface... BSD nm
.../node_modules/sodium-native install: checking whether ln -s works... yes
.../node_modules/sodium-native install: checking the maximum length of command line arguments... 3145728
.../node_modules/sodium-native install: checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
.../node_modules/sodium-native install: checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
.../node_modules/sodium-native install: checking for /usr/bin/ld option to reload object files... -r
.../node_modules/sodium-native install: checking for objdump... objdump
.../node_modules/sodium-native install: checking how to recognize dependent libraries... pass_all
.../node_modules/sodium-native install: checking for dlltool... no
.../node_modules/sodium-native install: checking how to associate runtime and link libraries... printf %s\n
.../node_modules/sodium-native install: checking for ar... ar
.../node_modules/sodium-native install: checking for archiver @FILE support... @
.../node_modules/sodium-native install: checking for strip... strip
.../node_modules/sodium-native install: checking for ranlib... ranlib
.../node_modules/sodium-native install: checking command to parse /usr/bin/nm -B output from gcc object... ok
.../node_modules/sodium-native install: checking for sysroot... no
.../node_modules/sodium-native install: checking for a working dd... /usr/bin/dd
.../node_modules/sodium-native install: checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
.../node_modules/sodium-native install: checking for mt... mt
.../node_modules/sodium-native install: checking if mt is a manifest tool... no
.../node_modules/sodium-native install: checking for dlfcn.h... yes
.../node_modules/sodium-native install: checking for objdir... .libs
.../node_modules/sodium-native install: checking if gcc supports -fno-rtti -fno-exceptions... no
.../node_modules/sodium-native install: checking for gcc option to produce PIC... -fPIC -DPIC
.../node_modules/sodium-native install: checking if gcc PIC flag -fPIC -DPIC works... yes
.../node_modules/sodium-native install: checking if gcc static flag -static works... yes
.../node_modules/sodium-native install: checking if gcc supports -c -o file.o... yes
.../node_modules/sodium-native install: checking if gcc supports -c -o file.o... (cached) yes
.../node_modules/sodium-native install: checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
.../node_modules/sodium-native install: checking whether -lc should be explicitly linked in... no
.../node_modules/sodium-native install: checking dynamic linker characteristics... GNU/Linux ld.so
.../node_modules/sodium-native install: checking how to hardcode library paths into programs... immediate
.../node_modules/sodium-native install: checking whether stripping libraries is possible... yes
.../node_modules/sodium-native install: checking if libtool supports shared libraries... yes
.../node_modules/sodium-native install: checking whether to build shared libraries... yes
.../node_modules/sodium-native install: checking whether to build static libraries... yes
.../node_modules/sodium-native install: checking for ar... (cached) ar
.../node_modules/sodium-native install: checking whether C compiler accepts -mmmx... yes
.../node_modules/sodium-native install: checking for MMX instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mmmx... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse2... yes
.../node_modules/sodium-native install: checking for SSE2 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse2... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse3... yes
.../node_modules/sodium-native install: checking for SSE3 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse3... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mssse3... yes
.../node_modules/sodium-native install: checking for SSSE3 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mssse3... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse4.1... yes
.../node_modules/sodium-native install: checking for SSE4.1 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -msse4.1... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx... yes
.../node_modules/sodium-native install: checking for AVX instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx2... yes
.../node_modules/sodium-native install: checking for AVX2 instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx2... (cached) yes
.../node_modules/sodium-native install: checking if _mm256_broadcastsi128_si256 is correctly defined... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx512f... yes
.../node_modules/sodium-native install: checking for AVX512F instructions set... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mavx512f... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -maes... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mpclmul... yes
.../node_modules/sodium-native install: checking for AESNI instructions set and PCLMULQDQ... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -maes... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mpclmul... (cached) yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mrdrnd... yes
.../node_modules/sodium-native install: checking for RDRAND... yes
.../node_modules/sodium-native install: checking whether C compiler accepts -mrdrnd... (cached) yes
.../node_modules/sodium-native install: checking sys/mman.h usability... yes
.../node_modules/sodium-native install: checking sys/mman.h presence... yes
.../node_modules/sodium-native install: checking for sys/mman.h... yes
.../node_modules/sodium-native install: checking intrin.h usability... no
.../node_modules/sodium-native install: checking intrin.h presence... no
.../node_modules/sodium-native install: checking for intrin.h... no
.../node_modules/sodium-native install: checking if _xgetbv() is available... no
.../node_modules/sodium-native install: checking for inline... inline
.../node_modules/sodium-native install: checking whether byte ordering is bigendian... (cached) no
.../node_modules/sodium-native install: checking whether __STDC_LIMIT_MACROS is required... no
.../node_modules/sodium-native install: checking whether we can use inline asm code... yes
.../node_modules/sodium-native install: no
.../node_modules/sodium-native install: checking whether we can use x86_64 asm code... yes
.../node_modules/sodium-native install: checking whether we can assemble AVX opcodes... yes
.../node_modules/sodium-native install: checking for 128-bit arithmetic... yes
.../node_modules/sodium-native install: checking for cpuid instruction... yes
.../node_modules/sodium-native install: checking if the .private_extern asm directive is supported... no
.../node_modules/sodium-native install: checking if the .hidden asm directive is supported... yes
.../node_modules/sodium-native install: checking if weak symbols are supported... yes
.../node_modules/sodium-native install: checking if data alignment is required... no
.../node_modules/sodium-native install: checking if atomic operations are supported... yes
.../node_modules/sodium-native install: checking for size_t... yes
.../node_modules/sodium-native install: checking for working alloca.h... yes
.../node_modules/sodium-native install: checking for alloca... yes
.../node_modules/sodium-native install: checking for arc4random... no
.../node_modules/sodium-native install: checking for arc4random_buf... no
.../node_modules/sodium-native install: checking for mmap... yes
.../node_modules/sodium-native install: checking for mlock... yes
.../node_modules/sodium-native install: checking for madvise... yes
.../node_modules/sodium-native install: checking for mprotect... yes
.../node_modules/sodium-native install: checking for memset_s... no
.../node_modules/sodium-native install: checking for explicit_bzero... yes
.../node_modules/sodium-native install: checking for explicit_memset... no
.../node_modules/sodium-native install: checking for nanosleep... yes
.../node_modules/sodium-native install: checking for posix_memalign... yes
.../node_modules/sodium-native install: checking for getpid... yes
.../node_modules/sodium-native install: checking if gcc/ld supports -Wl,--output-def... no
.../node_modules/sodium-native install: checking that generated files are newer than configure... done
.../node_modules/sodium-native install: configure: creating ./config.status
.../node_modules/sodium-native install: config.status: creating Makefile
.../node_modules/sodium-native install: config.status: creating builds/Makefile
.../node_modules/sodium-native install: config.status: creating contrib/Makefile
.../node_modules/sodium-native install: config.status: creating dist-build/Makefile
.../node_modules/sodium-native install: config.status: creating libsodium.pc
.../node_modules/sodium-native install: config.status: creating libsodium-uninstalled.pc
.../node_modules/sodium-native install: config.status: creating msvc-scripts/Makefile
.../node_modules/sodium-native install: config.status: creating src/Makefile
.../node_modules/sodium-native install: config.status: creating src/libsodium/Makefile
.../node_modules/sodium-native install: config.status: creating src/libsodium/include/Makefile
.../node_modules/sodium-native install: config.status: creating src/libsodium/include/sodium/version.h
.../node_modules/sodium-native install: config.status: creating test/default/Makefile
.../node_modules/sodium-native install: config.status: creating test/Makefile
.../node_modules/sodium-native install: config.status: executing depfiles commands
.../node_modules/sodium-native install: config.status: executing libtool commands
.../node_modules/sodium-native install: Making clean in builds
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: Making clean in contrib
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: Making clean in dist-build
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: Making clean in msvc-scripts
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: Making clean in src
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making clean in libsodium
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: Making clean in include
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: test -z "" || rm -f 
.../node_modules/sodium-native install: test -z "libsodium.la" || rm -f libsodium.la
.../node_modules/sodium-native install: rm -f ./so_locations
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -rf crypto_aead/aes256gcm/aesni/.libs crypto_aead/aes256gcm/aesni/_libs
.../node_modules/sodium-native install: rm -rf crypto_aead/chacha20poly1305/sodium/.libs crypto_aead/chacha20poly1305/sodium/_libs
.../node_modules/sodium-native install: rm -rf crypto_aead/xchacha20poly1305/sodium/.libs crypto_aead/xchacha20poly1305/sodium/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/.libs crypto_auth/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/hmacsha256/.libs crypto_auth/hmacsha256/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/hmacsha512/.libs crypto_auth/hmacsha512/_libs
.../node_modules/sodium-native install: rm -rf crypto_auth/hmacsha512256/.libs crypto_auth/hmacsha512256/_libs
.../node_modules/sodium-native install: rm -rf crypto_box/.libs crypto_box/_libs
.../node_modules/sodium-native install: rm -rf crypto_box/curve25519xchacha20poly1305/.libs crypto_box/curve25519xchacha20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_box/curve25519xsalsa20poly1305/.libs crypto_box/curve25519xsalsa20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/ed25519/.libs crypto_core/ed25519/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/ed25519/ref10/.libs crypto_core/ed25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/hchacha20/.libs crypto_core/hchacha20/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/hsalsa20/.libs crypto_core/hsalsa20/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/hsalsa20/ref2/.libs crypto_core/hsalsa20/ref2/_libs
.../node_modules/sodium-native install: rm -rf crypto_core/salsa/ref/.libs crypto_core/salsa/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_generichash/.libs crypto_generichash/_libs
.../node_modules/sodium-native install: rm -rf crypto_generichash/blake2b/.libs crypto_generichash/blake2b/_libs
.../node_modules/sodium-native install: rm -rf crypto_generichash/blake2b/ref/.libs crypto_generichash/blake2b/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/.libs crypto_hash/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha256/.libs crypto_hash/sha256/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha256/cp/.libs crypto_hash/sha256/cp/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha512/.libs crypto_hash/sha512/_libs
.../node_modules/sodium-native install: rm -rf crypto_hash/sha512/cp/.libs crypto_hash/sha512/cp/_libs
.../node_modules/sodium-native install: rm -rf crypto_kdf/.libs crypto_kdf/_libs
.../node_modules/sodium-native install: rm -rf crypto_kdf/blake2b/.libs crypto_kdf/blake2b/_libs
.../node_modules/sodium-native install: rm -rf crypto_kx/.libs crypto_kx/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/.libs crypto_onetimeauth/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/poly1305/.libs crypto_onetimeauth/poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/poly1305/donna/.libs crypto_onetimeauth/poly1305/donna/_libs
.../node_modules/sodium-native install: rm -rf crypto_onetimeauth/poly1305/sse2/.libs crypto_onetimeauth/poly1305/sse2/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/.libs crypto_pwhash/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/argon2/.libs crypto_pwhash/argon2/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/scryptsalsa208sha256/.libs crypto_pwhash/scryptsalsa208sha256/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/scryptsalsa208sha256/nosse/.libs crypto_pwhash/scryptsalsa208sha256/nosse/_libs
.../node_modules/sodium-native install: rm -rf crypto_pwhash/scryptsalsa208sha256/sse/.libs crypto_pwhash/scryptsalsa208sha256/sse/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/.libs crypto_scalarmult/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/curve25519/.libs crypto_scalarmult/curve25519/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/curve25519/ref10/.libs crypto_scalarmult/curve25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/curve25519/sandy2x/.libs crypto_scalarmult/curve25519/sandy2x/_libs
.../node_modules/sodium-native install: rm -rf crypto_scalarmult/ed25519/ref10/.libs crypto_scalarmult/ed25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretbox/.libs crypto_secretbox/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretbox/xchacha20poly1305/.libs crypto_secretbox/xchacha20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretbox/xsalsa20poly1305/.libs crypto_secretbox/xsalsa20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_secretstream/xchacha20poly1305/.libs crypto_secretstream/xchacha20poly1305/_libs
.../node_modules/sodium-native install: rm -rf crypto_shorthash/.libs crypto_shorthash/_libs
.../node_modules/sodium-native install: rm -rf crypto_shorthash/siphash24/.libs crypto_shorthash/siphash24/_libs
.../node_modules/sodium-native install: rm -rf crypto_shorthash/siphash24/ref/.libs crypto_shorthash/siphash24/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_sign/.libs crypto_sign/_libs
.../node_modules/sodium-native install: rm -rf crypto_sign/ed25519/.libs crypto_sign/ed25519/_libs
.../node_modules/sodium-native install: rm -rf crypto_sign/ed25519/ref10/.libs crypto_sign/ed25519/ref10/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/.libs crypto_stream/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/chacha20/.libs crypto_stream/chacha20/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/chacha20/dolbeau/.libs crypto_stream/chacha20/dolbeau/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/chacha20/ref/.libs crypto_stream/chacha20/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/.libs crypto_stream/salsa20/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/ref/.libs crypto_stream/salsa20/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/xmm6/.libs crypto_stream/salsa20/xmm6/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa20/xmm6int/.libs crypto_stream/salsa20/xmm6int/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa2012/.libs crypto_stream/salsa2012/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa2012/ref/.libs crypto_stream/salsa2012/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa208/.libs crypto_stream/salsa208/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/salsa208/ref/.libs crypto_stream/salsa208/ref/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/xchacha20/.libs crypto_stream/xchacha20/_libs
.../node_modules/sodium-native install: rm -rf crypto_stream/xsalsa20/.libs crypto_stream/xsalsa20/_libs
.../node_modules/sodium-native install: rm -rf crypto_verify/sodium/.libs crypto_verify/sodium/_libs
.../node_modules/sodium-native install: rm -rf randombytes/.libs randombytes/_libs
.../node_modules/sodium-native install: rm -rf randombytes/nativeclient/.libs randombytes/nativeclient/_libs
.../node_modules/sodium-native install: rm -rf randombytes/salsa20/.libs randombytes/salsa20/_libs
.../node_modules/sodium-native install: rm -rf randombytes/sysrandom/.libs randombytes/sysrandom/_libs
.../node_modules/sodium-native install: rm -rf sodium/.libs sodium/_libs
.../node_modules/sodium-native install: test -z "libaesni.la libsse2.la libssse3.la libsse41.la libavx2.la libavx512f.la librdrand.la" || rm -f libaesni.la libsse2.la libssse3.la libsse41.la libavx2.la libavx512f.la librdrand.la
.../node_modules/sodium-native install: rm -f ./so_locations
.../node_modules/sodium-native install: rm -f *.o
.../node_modules/sodium-native install: rm -f crypto_aead/aes256gcm/aesni/*.o
.../node_modules/sodium-native install: rm -f crypto_aead/aes256gcm/aesni/*.lo
.../node_modules/sodium-native install: rm -f crypto_aead/chacha20poly1305/sodium/*.o
.../node_modules/sodium-native install: rm -f crypto_aead/chacha20poly1305/sodium/*.lo
.../node_modules/sodium-native install: rm -f crypto_aead/xchacha20poly1305/sodium/*.o
.../node_modules/sodium-native install: rm -f crypto_aead/xchacha20poly1305/sodium/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha256/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha256/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512/*.lo
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512256/*.o
.../node_modules/sodium-native install: rm -f crypto_auth/hmacsha512256/*.lo
.../node_modules/sodium-native install: rm -f crypto_box/*.o
.../node_modules/sodium-native install: rm -f crypto_box/*.lo
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xchacha20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xchacha20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xsalsa20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_box/curve25519xsalsa20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/*.o
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_core/ed25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/hchacha20/*.o
.../node_modules/sodium-native install: rm -f crypto_core/hchacha20/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/*.o
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/ref2/*.o
.../node_modules/sodium-native install: rm -f crypto_core/hsalsa20/ref2/*.lo
.../node_modules/sodium-native install: rm -f crypto_core/salsa/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_core/salsa/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_generichash/*.o
.../node_modules/sodium-native install: rm -f crypto_generichash/*.lo
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/*.o
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/*.lo
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_generichash/blake2b/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/cp/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha256/cp/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/*.lo
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/cp/*.o
.../node_modules/sodium-native install: rm -f crypto_hash/sha512/cp/*.lo
.../node_modules/sodium-native install: rm -f crypto_kdf/*.o
.../node_modules/sodium-native install: rm -f crypto_kdf/*.lo
.../node_modules/sodium-native install: rm -f crypto_kdf/blake2b/*.o
.../node_modules/sodium-native install: rm -f crypto_kdf/blake2b/*.lo
.../node_modules/sodium-native install: rm -f crypto_kx/*.o
.../node_modules/sodium-native install: rm -f crypto_kx/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/donna/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/donna/*.lo
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/sse2/*.o
.../node_modules/sodium-native install: rm -f crypto_onetimeauth/poly1305/sse2/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/argon2/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/argon2/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/nosse/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/nosse/*.lo
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/sse/*.o
.../node_modules/sodium-native install: rm -f crypto_pwhash/scryptsalsa208sha256/sse/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/sandy2x/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/curve25519/sandy2x/*.lo
.../node_modules/sodium-native install: rm -f crypto_scalarmult/ed25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_scalarmult/ed25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretbox/*.o
.../node_modules/sodium-native install: rm -f crypto_secretbox/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretbox/xchacha20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_secretbox/xchacha20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretbox/xsalsa20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_secretbox/xsalsa20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_secretstream/xchacha20poly1305/*.o
.../node_modules/sodium-native install: rm -f crypto_secretstream/xchacha20poly1305/*.lo
.../node_modules/sodium-native install: rm -f crypto_shorthash/*.o
.../node_modules/sodium-native install: rm -f crypto_shorthash/*.lo
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/*.o
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/*.lo
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_shorthash/siphash24/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_sign/*.o
.../node_modules/sodium-native install: rm -f crypto_sign/*.lo
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/*.o
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/*.lo
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/ref10/*.o
.../node_modules/sodium-native install: rm -f crypto_sign/ed25519/ref10/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/dolbeau/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/dolbeau/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/chacha20/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6int/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa20/xmm6int/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa2012/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/ref/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/salsa208/ref/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/xchacha20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/xchacha20/*.lo
.../node_modules/sodium-native install: rm -f crypto_stream/xsalsa20/*.o
.../node_modules/sodium-native install: rm -f crypto_stream/xsalsa20/*.lo
.../node_modules/sodium-native install: rm -f crypto_verify/sodium/*.o
.../node_modules/sodium-native install: rm -f crypto_verify/sodium/*.lo
.../node_modules/sodium-native install: rm -f randombytes/*.o
.../node_modules/sodium-native install: rm -f randombytes/*.lo
.../node_modules/sodium-native install: rm -f randombytes/nativeclient/*.o
.../node_modules/sodium-native install: rm -f randombytes/nativeclient/*.lo
.../node_modules/sodium-native install: rm -f randombytes/salsa20/*.o
.../node_modules/sodium-native install: rm -f randombytes/salsa20/*.lo
.../node_modules/sodium-native install: rm -f randombytes/sysrandom/*.o
.../node_modules/sodium-native install: rm -f randombytes/sysrandom/*.lo
.../node_modules/sodium-native install: rm -f sodium/*.o
.../node_modules/sodium-native install: rm -f sodium/*.lo
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making clean in test
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: Making clean in default
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install:  rm -f aead_aes256gcm aead_aes256gcm2 aead_chacha20poly1305 aead_chacha20poly13052 aead_xchacha20poly1305 auth auth2 auth3 auth5 auth6 auth7 box box2 box7 box8 box_easy box_easy2 box_seal box_seed chacha20 codecs core1 core2 core3 core4 core5 core6 ed25519_convert generichash generichash2 generichash3 hash hash3 kdf keygen kx metamorphic misuse onetimeauth onetimeauth2 onetimeauth7 pwhash_argon2i pwhash_argon2id randombytes scalarmult scalarmult2 scalarmult5 scalarmult6 scalarmult7 scalarmult8 secretbox secretbox2 secretbox7 secretbox8 secretbox_easy secretbox_easy2 secretstream shorthash sign sodium_core sodium_utils sodium_version stream stream2 stream3 stream4 verify1 sodium_utils2 sodium_utils3 core_ed25519 pwhash_scrypt pwhash_scrypt_ll scalarmult_ed25519 siphashx24 xchacha20
.../node_modules/sodium-native install: test -z "" || rm -f 
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.o
.../node_modules/sodium-native install: test -z "aead_aes256gcm.log aead_aes256gcm2.log aead_chacha20poly1305.log aead_chacha20poly13052.log aead_xchacha20poly1305.log auth.log auth2.log auth3.log auth5.log auth6.log auth7.log box.log box2.log box7.log box8.log box_easy.log box_easy2.log box_seal.log box_seed.log chacha20.log codecs.log core1.log core2.log core3.log core4.log core5.log core6.log ed25519_convert.log generichash.log generichash2.log generichash3.log hash.log hash3.log kdf.log keygen.log kx.log metamorphic.log misuse.log onetimeauth.log onetimeauth2.log onetimeauth7.log pwhash_argon2i.log pwhash_argon2id.log randombytes.log scalarmult.log scalarmult2.log scalarmult5.log scalarmult6.log scalarmult7.log scalarmult8.log secretbox.log secretbox2.log secretbox7.log secretbox8.log secretbox_easy.log secretbox_easy2.log secretstream.log shorthash.log sign.log sodium_core.log sodium_utils.log sodium_version.log stream.log stream2.log stream3.log stream4.log verify1.log sodium_utils2.log sodium_utils3.log core_ed25519.log pwhash_scrypt.log pwhash_scrypt_ll.log scalarmult_ed25519.log siphashx24.log xchacha20.log" || rm -f aead_aes256gcm.log aead_aes256gcm2.log aead_chacha20poly1305.log aead_chacha20poly13052.log aead_xchacha20poly1305.log auth.log auth2.log auth3.log auth5.log auth6.log auth7.log box.log box2.log box7.log box8.log box_easy.log box_easy2.log box_seal.log box_seed.log chacha20.log codecs.log core1.log core2.log core3.log core4.log core5.log core6.log ed25519_convert.log generichash.log generichash2.log generichash3.log hash.log hash3.log kdf.log keygen.log kx.log metamorphic.log misuse.log onetimeauth.log onetimeauth2.log onetimeauth7.log pwhash_argon2i.log pwhash_argon2id.log randombytes.log scalarmult.log scalarmult2.log scalarmult5.log scalarmult6.log scalarmult7.log scalarmult8.log secretbox.log secretbox2.log secretbox7.log secretbox8.log secretbox_easy.log secretbox_easy2.log secretstream.log shorthash.log sign.log sodium_core.log sodium_utils.log sodium_version.log stream.log stream2.log stream3.log stream4.log verify1.log sodium_utils2.log sodium_utils3.log core_ed25519.log pwhash_scrypt.log pwhash_scrypt_ll.log scalarmult_ed25519.log siphashx24.log xchacha20.log
.../node_modules/sodium-native install: test -z "aead_aes256gcm.trs aead_aes256gcm2.trs aead_chacha20poly1305.trs aead_chacha20poly13052.trs aead_xchacha20poly1305.trs auth.trs auth2.trs auth3.trs auth5.trs auth6.trs auth7.trs box.trs box2.trs box7.trs box8.trs box_easy.trs box_easy2.trs box_seal.trs box_seed.trs chacha20.trs codecs.trs core1.trs core2.trs core3.trs core4.trs core5.trs core6.trs ed25519_convert.trs generichash.trs generichash2.trs generichash3.trs hash.trs hash3.trs kdf.trs keygen.trs kx.trs metamorphic.trs misuse.trs onetimeauth.trs onetimeauth2.trs onetimeauth7.trs pwhash_argon2i.trs pwhash_argon2id.trs randombytes.trs scalarmult.trs scalarmult2.trs scalarmult5.trs scalarmult6.trs scalarmult7.trs scalarmult8.trs secretbox.trs secretbox2.trs secretbox7.trs secretbox8.trs secretbox_easy.trs secretbox_easy2.trs secretstream.trs shorthash.trs sign.trs sodium_core.trs sodium_utils.trs sodium_version.trs stream.trs stream2.trs stream3.trs stream4.trs verify1.trs sodium_utils2.trs sodium_utils3.trs core_ed25519.trs pwhash_scrypt.trs pwhash_scrypt_ll.trs scalarmult_ed25519.trs siphashx24.trs xchacha20.trs" || rm -f aead_aes256gcm.trs aead_aes256gcm2.trs aead_chacha20poly1305.trs aead_chacha20poly13052.trs aead_xchacha20poly1305.trs auth.trs auth2.trs auth3.trs auth5.trs auth6.trs auth7.trs box.trs box2.trs box7.trs box8.trs box_easy.trs box_easy2.trs box_seal.trs box_seed.trs chacha20.trs codecs.trs core1.trs core2.trs core3.trs core4.trs core5.trs core6.trs ed25519_convert.trs generichash.trs generichash2.trs generichash3.trs hash.trs hash3.trs kdf.trs keygen.trs kx.trs metamorphic.trs misuse.trs onetimeauth.trs onetimeauth2.trs onetimeauth7.trs pwhash_argon2i.trs pwhash_argon2id.trs randombytes.trs scalarmult.trs scalarmult2.trs scalarmult5.trs scalarmult6.trs scalarmult7.trs scalarmult8.trs secretbox.trs secretbox2.trs secretbox7.trs secretbox8.trs secretbox_easy.trs secretbox_easy2.trs secretstream.trs shorthash.trs sign.trs sodium_core.trs sodium_utils.trs sodium_version.trs stream.trs stream2.trs stream3.trs stream4.trs verify1.trs sodium_utils2.trs sodium_utils3.trs core_ed25519.trs pwhash_scrypt.trs pwhash_scrypt_ll.trs scalarmult_ed25519.trs siphashx24.trs xchacha20.trs
.../node_modules/sodium-native install: test -z "test-suite.log" || rm -f test-suite.log
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: rm -rf .libs _libs
.../node_modules/sodium-native install: rm -f *.lo
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: Making install in builds
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/builds'
.../node_modules/sodium-native install: Making install in contrib
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/contrib'
.../node_modules/sodium-native install: Making install in dist-build
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/dist-build'
.../node_modules/sodium-native install: Making install in msvc-scripts
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/msvc-scripts'
.../node_modules/sodium-native install: Making install in src
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making install in libsodium
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: Making install in include
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[4]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[4]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium/core.h sodium/crypto_aead_aes256gcm.h sodium/crypto_aead_chacha20poly1305.h sodium/crypto_aead_xchacha20poly1305.h sodium/crypto_auth.h sodium/crypto_auth_hmacsha256.h sodium/crypto_auth_hmacsha512.h sodium/crypto_auth_hmacsha512256.h sodium/crypto_box.h sodium/crypto_box_curve25519xchacha20poly1305.h sodium/crypto_box_curve25519xsalsa20poly1305.h sodium/crypto_core_ed25519.h sodium/crypto_core_hchacha20.h sodium/crypto_core_hsalsa20.h sodium/crypto_core_salsa20.h sodium/crypto_core_salsa2012.h sodium/crypto_core_salsa208.h sodium/crypto_generichash.h sodium/crypto_generichash_blake2b.h sodium/crypto_hash.h sodium/crypto_hash_sha256.h sodium/crypto_hash_sha512.h sodium/crypto_kdf.h sodium/crypto_kdf_blake2b.h sodium/crypto_kx.h sodium/crypto_onetimeauth.h sodium/crypto_onetimeauth_poly1305.h sodium/crypto_pwhash.h sodium/crypto_pwhash_argon2i.h sodium/crypto_pwhash_argon2id.h sodium/crypto_pwhash_scryptsalsa208sha256.h sodium/crypto_scalarmult.h sodium/crypto_scalarmult_curve25519.h sodium/crypto_scalarmult_ed25519.h sodium/crypto_secretbox.h sodium/crypto_secretbox_xchacha20poly1305.h sodium/crypto_secretbox_xsalsa20poly1305.h sodium/crypto_secretstream_xchacha20poly1305.h sodium/crypto_shorthash.h sodium/crypto_shorthash_siphash24.h '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium/crypto_sign.h sodium/crypto_sign_ed25519.h sodium/crypto_sign_edwards25519sha512batch.h sodium/crypto_stream.h sodium/crypto_stream_chacha20.h sodium/crypto_stream_salsa20.h sodium/crypto_stream_salsa2012.h sodium/crypto_stream_salsa208.h sodium/crypto_stream_xchacha20.h sodium/crypto_stream_xsalsa20.h sodium/crypto_verify_16.h sodium/crypto_verify_32.h sodium/crypto_verify_64.h sodium/export.h sodium/randombytes.h sodium/randombytes_salsa20_random.h sodium/randombytes_sysrandom.h sodium/runtime.h sodium/utils.h '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium.h '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/.'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644  sodium/version.h '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/include/sodium'
.../node_modules/sodium-native install: make[4]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium/include'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install:   CC       crypto_aead/chacha20poly1305/sodium/libsodium_la-aead_chacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_aead/xchacha20poly1305/sodium/libsodium_la-aead_xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_auth/libsodium_la-crypto_auth.lo
.../node_modules/sodium-native install:   CC       crypto_auth/hmacsha256/libsodium_la-auth_hmacsha256.lo
.../node_modules/sodium-native install:   CC       crypto_auth/hmacsha512/libsodium_la-auth_hmacsha512.lo
.../node_modules/sodium-native install:   CC       crypto_auth/hmacsha512256/libsodium_la-auth_hmacsha512256.lo
.../node_modules/sodium-native install:   CC       crypto_box/libsodium_la-crypto_box.lo
.../node_modules/sodium-native install:   CC       crypto_box/libsodium_la-crypto_box_easy.lo
.../node_modules/sodium-native install:   CC       crypto_box/libsodium_la-crypto_box_seal.lo
.../node_modules/sodium-native install:   CC       crypto_box/curve25519xsalsa20poly1305/libsodium_la-box_curve25519xsalsa20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_core/ed25519/ref10/libsodium_la-ed25519_ref10.lo
.../node_modules/sodium-native install:   CC       crypto_core/hchacha20/libsodium_la-core_hchacha20.lo
.../node_modules/sodium-native install:   CC       crypto_core/hsalsa20/ref2/libsodium_la-core_hsalsa20_ref2.lo
.../node_modules/sodium-native install:   CC       crypto_core/hsalsa20/libsodium_la-core_hsalsa20.lo
.../node_modules/sodium-native install:   CC       crypto_core/salsa/ref/libsodium_la-core_salsa_ref.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/libsodium_la-crypto_generichash.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/libsodium_la-generichash_blake2.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsodium_la-blake2b-compress-ref.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsodium_la-blake2b-ref.lo
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsodium_la-generichash_blake2b.lo
.../node_modules/sodium-native install:   CC       crypto_hash/libsodium_la-crypto_hash.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha256/libsodium_la-hash_sha256.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha256/cp/libsodium_la-hash_sha256_cp.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha512/libsodium_la-hash_sha512.lo
.../node_modules/sodium-native install:   CC       crypto_hash/sha512/cp/libsodium_la-hash_sha512_cp.lo
.../node_modules/sodium-native install:   CC       crypto_kdf/blake2b/libsodium_la-kdf_blake2b.lo
.../node_modules/sodium-native install:   CC       crypto_kdf/libsodium_la-crypto_kdf.lo
.../node_modules/sodium-native install:   CC       crypto_kx/libsodium_la-crypto_kx.lo
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/libsodium_la-crypto_onetimeauth.lo
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/poly1305/libsodium_la-onetimeauth_poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/poly1305/donna/libsodium_la-poly1305_donna.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2-core.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2-encoding.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2-fill-block-ref.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-argon2.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-blake2b-long.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-pwhash_argon2i.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libsodium_la-pwhash_argon2id.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/libsodium_la-crypto_pwhash.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/libsodium_la-crypto_scalarmult.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/ref10/libsodium_la-x25519_ref10.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/libsodium_la-scalarmult_curve25519.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/libsodium_la-crypto_secretbox.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/libsodium_la-crypto_secretbox_easy.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/xsalsa20poly1305/libsodium_la-secretbox_xsalsa20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_secretstream/xchacha20poly1305/libsodium_la-secretstream_xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/libsodium_la-crypto_shorthash.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/libsodium_la-shorthash_siphash24.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/ref/libsodium_la-shorthash_siphash24_ref.lo
.../node_modules/sodium-native install:   CC       crypto_sign/libsodium_la-crypto_sign.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/libsodium_la-sign_ed25519.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-keypair.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-open.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-sign.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/libsodium_la-stream_chacha20.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/ref/libsodium_la-chacha20_ref.lo
.../node_modules/sodium-native install:   CC       crypto_stream/libsodium_la-crypto_stream.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa20/libsodium_la-stream_salsa20.lo
.../node_modules/sodium-native install:   CC       crypto_stream/xsalsa20/libsodium_la-stream_xsalsa20.lo
.../node_modules/sodium-native install:   CC       crypto_verify/sodium/libsodium_la-verify.lo
.../node_modules/sodium-native install:   CC       randombytes/libsodium_la-randombytes.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-codecs.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-core.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-runtime.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-utils.lo
.../node_modules/sodium-native install:   CC       sodium/libsodium_la-version.lo
.../node_modules/sodium-native install:   CPPAS    crypto_stream/salsa20/xmm6/libsodium_la-salsa20_xmm6-asm.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa20/xmm6/libsodium_la-salsa20_xmm6.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/sandy2x/libsodium_la-curve25519_sandy2x.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/sandy2x/libsodium_la-fe51_invert.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/curve25519/sandy2x/libsodium_la-fe_frombytes_sandy2x.lo
.../node_modules/sodium-native install:   CPPAS    crypto_scalarmult/curve25519/sandy2x/libsodium_la-sandy2x.lo
.../node_modules/sodium-native install:   CC       crypto_box/curve25519xchacha20poly1305/libsodium_la-box_curve25519xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_box/curve25519xchacha20poly1305/libsodium_la-box_seal_curve25519xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_core/ed25519/libsodium_la-core_ed25519.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-crypto_scrypt-common.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-scrypt_platform.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-pbkdf2-sha256.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/libsodium_la-pwhash_scryptsalsa208sha256.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/nosse/libsodium_la-pwhash_scryptsalsa208sha256_nosse.lo
.../node_modules/sodium-native install:   CC       crypto_scalarmult/ed25519/ref10/libsodium_la-scalarmult_ed25519_ref10.lo
.../node_modules/sodium-native install:   CC       crypto_secretbox/xchacha20poly1305/libsodium_la-secretbox_xchacha20poly1305.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/libsodium_la-shorthash_siphashx24.lo
.../node_modules/sodium-native install:   CC       crypto_shorthash/siphash24/ref/libsodium_la-shorthash_siphashx24_ref.lo
.../node_modules/sodium-native install:   CC       crypto_sign/ed25519/ref10/libsodium_la-obsolete.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa2012/ref/libsodium_la-stream_salsa2012_ref.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa2012/libsodium_la-stream_salsa2012.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa208/ref/libsodium_la-stream_salsa208_ref.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa208/libsodium_la-stream_salsa208.lo
.../node_modules/sodium-native install:   CC       crypto_stream/xchacha20/libsodium_la-stream_xchacha20.lo
.../node_modules/sodium-native install:   CC       randombytes/sysrandom/libsodium_la-randombytes_sysrandom.lo
.../node_modules/sodium-native install:   CC       crypto_aead/aes256gcm/aesni/libaesni_la-aead_aes256gcm_aesni.lo
.../node_modules/sodium-native install:   CCLD     libaesni.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_onetimeauth/poly1305/sse2/libsse2_la-poly1305_sse2.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/scryptsalsa208sha256/sse/libsse2_la-pwhash_scryptsalsa208sha256_sse.lo
.../node_modules/sodium-native install:   CCLD     libsse2.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libssse3_la-blake2b-compress-ssse3.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libssse3_la-argon2-fill-block-ssse3.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/dolbeau/libssse3_la-chacha20_dolbeau-ssse3.lo
.../node_modules/sodium-native install:   CCLD     libssse3.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libsse41_la-blake2b-compress-sse41.lo
.../node_modules/sodium-native install:   CCLD     libsse41.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_generichash/blake2b/ref/libavx2_la-blake2b-compress-avx2.lo
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libavx2_la-argon2-fill-block-avx2.lo
.../node_modules/sodium-native install:   CC       crypto_stream/chacha20/dolbeau/libavx2_la-chacha20_dolbeau-avx2.lo
.../node_modules/sodium-native install:   CC       crypto_stream/salsa20/xmm6int/libavx2_la-salsa20_xmm6int-avx2.lo
.../node_modules/sodium-native install:   CCLD     libavx2.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       crypto_pwhash/argon2/libavx512f_la-argon2-fill-block-avx512f.lo
.../node_modules/sodium-native install:   CCLD     libavx512f.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CC       randombytes/salsa20/librdrand_la-randombytes_salsa20_random.lo
.../node_modules/sodium-native install:   CCLD     librdrand.la
.../node_modules/sodium-native install: libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
.../node_modules/sodium-native install:   CCLD     libsodium.la
.../node_modules/sodium-native install: make[4]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib'
.../node_modules/sodium-native install:  /bin/bash ../../libtool   --mode=install /usr/bin/install -c   libsodium.la '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib'
.../node_modules/sodium-native install: libtool: install: /usr/bin/install -c .libs/libsodium.so.23.2.0 /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.so.23.2.0
.../node_modules/sodium-native install: libtool: install: (cd /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib && { ln -s -f libsodium.so.23.2.0 libsodium.so.23 || { rm -f libsodium.so.23 && ln -s libsodium.so.23.2.0 libsodium.so.23; }; })
.../node_modules/sodium-native install: libtool: install: (cd /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib && { ln -s -f libsodium.so.23.2.0 libsodium.so || { rm -f libsodium.so && ln -s libsodium.so.23.2.0 libsodium.so; }; })
.../node_modules/sodium-native install: libtool: install: /usr/bin/install -c .libs/libsodium.lai /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.la
.../node_modules/sodium-native install: libtool: install: /usr/bin/install -c .libs/libsodium.a /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.a
.../node_modules/sodium-native install: libtool: install: chmod 644 /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.a
.../node_modules/sodium-native install: libtool: install: ranlib /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/libsodium.a
.../node_modules/sodium-native install: libtool: finish: PATH="/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/node_modules/.bin:/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/.bin:/home/runner/work/cli/cli/common/temp/node_modules/.bin:/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node-gyp-bin:/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/node_modules/.bin:/home/runner/work/cli/cli/common/temp/node_modules/.bin:/home/runner/work/cli/cli/common/temp/node_modules/.bin:/home/runner/work/cli/cli/common/temp/install-run/@microsoft+rush@5.58.0/node_modules/.bin:/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin:/opt/hostedtoolcache/node/16.1.0/x64/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/sbin" ldconfig -n /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib
.../node_modules/sodium-native install: ----------------------------------------------------------------------
.../node_modules/sodium-native install: Libraries have been installed in:
.../node_modules/sodium-native install:    /home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib
.../node_modules/sodium-native install: If you ever happen to want to link against installed libraries
.../node_modules/sodium-native install: in a given directory, LIBDIR, you must either use libtool, and
.../node_modules/sodium-native install: specify the full pathname of the library, or use the '-LLIBDIR'
.../node_modules/sodium-native install: flag during linking and do at least one of the following:
.../node_modules/sodium-native install:    - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
.../node_modules/sodium-native install:      during execution
.../node_modules/sodium-native install:    - add LIBDIR to the 'LD_RUN_PATH' environment variable
.../node_modules/sodium-native install:      during linking
.../node_modules/sodium-native install:    - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
.../node_modules/sodium-native install:    - have your system administrator add LIBDIR to '/etc/ld.so.conf'
.../node_modules/sodium-native install: See any operating system documentation about shared libraries for
.../node_modules/sodium-native install: more information, such as the ld(1) and ld.so(8) manual pages.
.../node_modules/sodium-native install: ----------------------------------------------------------------------
.../node_modules/sodium-native install: make[4]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[4]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src/libsodium'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/src'
.../node_modules/sodium-native install: Making install in test
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: Making install in default
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test/default'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[3]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install: make[3]: Nothing to be done for 'install-data-am'.
.../node_modules/sodium-native install: make[3]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium/test'
.../node_modules/sodium-native install: make[1]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: make[2]: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: make[2]: Nothing to be done for 'install-exec-am'.
.../node_modules/sodium-native install:  /usr/bin/mkdir -p '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/pkgconfig'
.../node_modules/sodium-native install:  /usr/bin/install -c -m 644 libsodium.pc '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/tmp/lib/pkgconfig'
.../node_modules/sodium-native install: make[2]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: make[1]: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/libsodium'
.../node_modules/sodium-native install: gyp info it worked if it ends with ok
.../node_modules/sodium-native install: gyp info using node-gyp@8.4.1
.../node_modules/sodium-native install: gyp info using node@16.1.0 | linux | x64
.../node_modules/sodium-native install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../node_modules/sodium-native install: gyp info spawn /usr/bin/python3
.../node_modules/sodium-native install: gyp info spawn args [
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../node_modules/sodium-native install: gyp info spawn args   'binding.gyp',
.../node_modules/sodium-native install: gyp info spawn args   '-f',
.../node_modules/sodium-native install: gyp info spawn args   'make',
.../node_modules/sodium-native install: gyp info spawn args   '-I',
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/build/config.gypi',
.../node_modules/sodium-native install: gyp info spawn args   '-I',
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../node_modules/sodium-native install: gyp info spawn args   '-I',
.../node_modules/sodium-native install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../node_modules/sodium-native install: gyp info spawn args   '-Dlibrary=shared_library',
.../node_modules/sodium-native install: gyp info spawn args   '-Dvisibility=default',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../node_modules/sodium-native install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native',
.../node_modules/sodium-native install: gyp info spawn args   '-Dnode_engine=v8',
.../node_modules/sodium-native install: gyp info spawn args   '--depth=.',
.../node_modules/sodium-native install: gyp info spawn args   '--no-parallel',
.../node_modules/sodium-native install: gyp info spawn args   '--generator-output',
.../node_modules/sodium-native install: gyp info spawn args   'build',
.../node_modules/sodium-native install: gyp info spawn args   '-Goutput_dir=.'
.../node_modules/sodium-native install: gyp info spawn args ]
.../node_modules/sodium-native install: gyp info spawn make
.../node_modules/sodium-native install: make: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/build'
.../node_modules/sodium-native install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/binding.o
.../node_modules/sodium-native install: In file included from ../src/crypto_pwhash_async.cc:2,
.../node_modules/sodium-native install:                  from ../binding.cc:12:
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sodium_malloc(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:49:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:    49 |   ASSERT_UINT_BOUNDS(info[0], size, 0, 0, `buffer.constants.MAX_LENGTH`, node::Buffer::kMaxLength)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE randombytes_uniform(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:95:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:    95 |   ASSERT_UINT_BOUNDS(info[0], upper_bound, 0, 0, 0xffffffff, 0xffffffff)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sodium_pad(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:157:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:   157 |   ASSERT_UINT_BOUNDS(info[1], unpadded_buflen, 0, 0, `buf.length`, buf_length)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE sodium_unpad(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/macros.h:102:24: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
.../node_modules/sodium-native install:   102 |   if (((uint64_t) var) < min) { \
.../node_modules/sodium-native install: ../binding.cc:169:3: note: in expansion of macro ‘ASSERT_UINT_BOUNDS’
.../node_modules/sodium-native install:   169 |   ASSERT_UINT_BOUNDS(info[1], padded_buflen, 0, 0, `buf.length`, buf_length)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~~~~~~
.../node_modules/sodium-native install: In file included from ../binding.cc:1:
.../node_modules/sodium-native install: ../binding.cc: At global scope:
.../node_modules/sodium-native install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../node_modules/sodium-native install:   806 |       (node::addon_register_func) (regfunc),                          \
.../node_modules/sodium-native install:       |                                           ^
.../node_modules/sodium-native install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../node_modules/sodium-native install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../node_modules/sodium-native install:       |   ^~~~~~~~~~~~~
.../node_modules/sodium-native install: ../binding.cc:1593:1: note: in expansion of macro ‘NODE_MODULE’
.../node_modules/sodium-native install:  1593 | NODE_MODULE(sodium, InitAll)
.../node_modules/sodium-native install:       | ^~~~~~~~~~~
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_hash_sha256_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_hash_sha512_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_generichash_wrap.o
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE CryptoGenericHashWrap::New(Nan::NAN_METHOD_ARGS_TYPE)’:
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc:11:58: warning: ‘new’ of type ‘CryptoGenericHashWrap’ with extended alignment 64 [-Waligned-new=]
.../node_modules/sodium-native install:    11 |   CryptoGenericHashWrap* obj = new CryptoGenericHashWrap();
.../node_modules/sodium-native install:       |                                                          ^
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc:11:58: note: uses ‘void* operator new(std::size_t)’, which does not have an alignment parameter
.../node_modules/sodium-native install: ../src/crypto_generichash_wrap.cc:11:58: note: use ‘-faligned-new’ to enable C++17 over-aligned new support
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_onetimeauth_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_stream_xor_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_stream_chacha20_xor_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_secretstream_xchacha20poly1305_state_wrap.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_str_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_str_verify_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_scryptsalsa208sha256_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_scryptsalsa208sha256_str_async.o
.../node_modules/sodium-native install:   CXX(target) Release/obj.target/sodium/src/crypto_pwhash_scryptsalsa208sha256_str_verify_async.o
.../node_modules/sodium-native install:   SOLINK_MODULE(target) Release/obj.target/sodium.node
.../node_modules/sodium-native install:   COPY Release/sodium.node
.../node_modules/sodium-native install: make: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/sodium-native@2.4.9/node_modules/sodium-native/build'
.../node_modules/sodium-native install: gyp info ok 
.../node_modules/sodium-native install: Done
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install$ node install.js
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install$ node scripts/download-prebuilt.js
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info it worked if it ends with ok
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info using node-gyp@8.4.1
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info using node@16.1.0 | linux | x64
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info it worked if it ends with ok
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info using node-pre-gyp@0.13.0
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info using node@16.1.0 | linux | x64
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp WARN Using needle for node-pre-gyp https download 
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info check checked for "/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/wrtc@0.4.7/node_modules/wrtc/build/Release/wrtc.node" (not found)
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp http GET https://node-webrtc.s3.amazonaws.com/wrtc/v0.4.7/Release/linux-x64.tar.gz
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info find Python using Python version 3.8.10 found at "/usr/bin/python3"
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp http 200 https://node-webrtc.s3.amazonaws.com/wrtc/v0.4.7/Release/linux-x64.tar.gz
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info install unpacking Release/wrtc.node
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn /usr/bin/python3
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args [
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/gyp/gyp_main.py',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   'binding.gyp',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-f',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   'make',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-I',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/ssh2@1.5.0/node_modules/ssh2/lib/protocol/crypto/build/config.gypi',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-I',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp/addon.gypi',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-I',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '/home/runner/.cache/node-gyp/16.1.0/include/node/common.gypi',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Dlibrary=shared_library',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Dvisibility=default',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Dnode_root_dir=/home/runner/.cache/node-gyp/16.1.0',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Dnode_gyp_dir=/home/runner/.rush/node-v16.1.0/pnpm-6.24.2/node_modules/pnpm/dist/node_modules/node-gyp',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Dnode_lib_file=/home/runner/.cache/node-gyp/16.1.0/<(target_arch)/node.lib',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Dmodule_root_dir=/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/ssh2@1.5.0/node_modules/ssh2/lib/protocol/crypto',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Dnode_engine=v8',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '--depth=.',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '--no-parallel',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '--generator-output',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   'build',
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args   '-Goutput_dir=.'
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args ]
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn make
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: make: Entering directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/ssh2@1.5.0/node_modules/ssh2/lib/protocol/crypto/build'
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:   CXX(target) Release/obj.target/sshcrypto/src/binding.o
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info tarball done parsing tarball
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: node-pre-gyp info ok 
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: [wrtc] Success: "/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/wrtc@0.4.7/node_modules/wrtc/build/Release/wrtc.node" is installed via remote
.../.pnpm/wrtc@0.4.7/node_modules/wrtc install: Done
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: In file included from ../src/binding.cc:6:
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:806:43: warning: cast between incompatible function types from ‘void (*)(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)’ {aka ‘void (*)(v8::Local<v8::Object>)’} to ‘node::addon_register_func’ {aka ‘void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)’} [-Wcast-function-type]
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:   806 |       (node::addon_register_func) (regfunc),                          \
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:       |                                           ^
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: /home/runner/.cache/node-gyp/16.1.0/include/node/node.h:840:3: note: in expansion of macro ‘NODE_MODULE_X’
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:   840 |   NODE_MODULE_X(modname, regfunc, NULL, 0)  // NOLINT (readability/null_usage)
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:       |   ^~~~~~~~~~~~~
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: ../src/binding.cc:2003:1: note: in expansion of macro ‘NODE_MODULE’
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:  2003 | NODE_MODULE(sshcrypto, init)
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:       | ^~~~~~~~~~~
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:   SOLINK_MODULE(target) Release/obj.target/sshcrypto.node
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install:   COPY Release/sshcrypto.node
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: make: Leaving directory '/home/runner/work/cli/cli/common/temp/node_modules/.pnpm/ssh2@1.5.0/node_modules/ssh2/lib/protocol/crypto/build'
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: gyp info ok 
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: Succeeded in building optional crypto binding
.../.pnpm/ssh2@1.5.0/node_modules/ssh2 install: Done
../../packages/cli preinstall$ npm run checkNew && npm run checkOld
../../packages/cli preinstall: > @dxos/cli@2.12.4 checkNew
../../packages/cli preinstall: > [ ! -d ~/.wire ] && [ ! -d ~/.dx ] && mkdir -p ~/.dx || true
../../packages/cli preinstall: > @dxos/cli@2.12.4 checkOld
../../packages/cli preinstall: > [ -d ~/.wire ] && [ ! -L ~/.dx ] && ln -s ~/.wire ~/.dx || true
../../packages/cli preinstall: Done

Copying "/home/runner/work/cli/cli/common/temp/pnpm-lock.yaml"
  --> "/home/runner/work/cli/cli/common/config/rush/pnpm-lock.yaml"


Rush update finished successfully. (1 minute 49.9 seconds)
```

### stderr:

```Shell
npm WARN deprecated read-package-tree@5.1.6: The functionality that this package provided is now in @npmcli/arborist
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated @opentelemetry/types@0.2.0: Package renamed to @opentelemetry/api, see https://github.com/open-telemetry/opentelemetry-js
Your version of Node.js (16.1.0) is not a Long-Term Support (LTS) release. These versions frequently have bugs. Please consider installing a stable release.
```

</details>
<details>
<summary><em>rm -rf .npmrc</em></summary>



</details>

</details>

## Changed files
<details>
<summary>Changed 19 files: </summary>

- common/config/rush/pnpm-lock.yaml
- docs/package.json
- packages/cli-app/package.json
- packages/cli-bot/package.json
- packages/cli-chat/package.json
- packages/cli-console/package.json
- packages/cli-core/package.json
- packages/cli-data/package.json
- packages/cli-dxns/package.json
- packages/cli-echo/package.json
- packages/cli-halo/package.json
- packages/cli-ipfs/package.json
- packages/cli-kube/package.json
- packages/cli-mdns/package.json
- packages/cli-mesh/package.json
- packages/cli-pad/package.json
- packages/cli-signal/package.json
- packages/cli/package.json
- packages/e2e/package.json

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)